### PR TITLE
change system type and family strings

### DIFF
--- a/witherspoon.xml
+++ b/witherspoon.xml
@@ -7061,7 +7061,7 @@
 	</attribute>
 	<attribute>
 		<id>SYSTEM_FAMILY</id>
-		<default>ibm,p9</default>
+		<default>ibm,p9-openbmc</default>
 	</attribute>
 	<attribute>
 		<id>SYSTEM_IPL_PHASE</id>
@@ -7093,7 +7093,7 @@
 	</attribute>
 	<attribute>
 		<id>SYSTEM_TYPE</id>
-		<default>ibm,miscopenpower</default>
+		<default>ibm,witherspoon</default>
 	</attribute>
 	<attribute>
 		<id>SYSTEM_WOF_ENABLED</id>


### PR DESCRIPTION
Changes the system type string to "ibm,witherspoon" and the family
string to "ibm,p9-openbmc" so we can add a witherspoon specific
platform to Skiboot.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>