### PR TITLE
Wire up fsi_bit_bang part

### DIFF
--- a/witherspoon.xml
+++ b/witherspoon.xml
@@ -2462,6 +2462,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1</id>
+	<property>
+	<id>FRU_ID</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/BCM5719-0</id>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -2646,10 +2653,40 @@
 	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_B20_gpioe0e7_uart3</id>
 	<property>
 	<id>IO_CONFIG_SELECT</id>
-	<value></value>
+	<value>1</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_B20_gpioe0e7_uart3/chip-bmc-ast2500.pingroup_gpioe0e7</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_B20_gpioe0e7_uart3/chip-bmc-ast2500.pingroup_gpioe0e7/chip-bmc-ast2500.GPIOE0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -2729,6 +2766,47 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_C13_gpioa6_timer7</id>
+	<property>
+	<id>IO_CONFIG_SELECT</id>
+	<value>1</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_C13_gpioa6_timer7/chip-bmc-ast2500.pingroup_gpioa6</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_C13_gpioa6_timer7/chip-bmc-ast2500.pingroup_gpioa6/chip-bmc-ast2500.GPIOA6</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_C14_gpioa4_timer5_i2c9/chip-bmc-ast2500.pingroup_i2c9/chip-bmc-ast2500.I2C9</id>
 	<property>
 	<id>DIRECTION</id>
@@ -2761,6 +2839,47 @@
 	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_C2_rgmii2_rmii2_gpiov2u3/chip-bmc-ast2500.rmii2</id>
 	<property>
 	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_F19_gpiod0d7_sd</id>
+	<property>
+	<id>IO_CONFIG_SELECT</id>
+	<value>1</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_F19_gpiod0d7_sd/chip-bmc-ast2500.pingroup_gpiod0d7</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_F19_gpiod0d7_sd/chip-bmc-ast2500.pingroup_gpiod0d7/chip-bmc-ast2500.GPIOD0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -2878,10 +2997,40 @@
 	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_T17_gpior2r5_spi2</id>
 	<property>
 	<id>IO_CONFIG_SELECT</id>
-	<value></value>
+	<value>1</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_T17_gpior2r5_spi2/chip-bmc-ast2500.pingroup_gpior2r5</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_T17_gpior2r5_spi2/chip-bmc-ast2500.pingroup_gpior2r5/chip-bmc-ast2500.GPIOR2</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -3073,9 +3222,165 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_Y21_gpioaa0</id>
+	<property>
+	<id>IO_CONFIG_SELECT</id>
+	<value>1</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_Y21_gpioaa0/chip-bmc-ast2500.pingroup_gpioaa0</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_Y21_gpioaa0/chip-bmc-ast2500.pingroup_gpioaa0/chip-bmc-ast2500.GPIOAA0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/bmcserialconnector-1/chip-uartslave.uart-0</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/fsi_bit_bang-0/fsi_bit_bang.fsi_clk-0</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/fsi_bit_bang-0/fsi_bit_bang.fsi_dat-1</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/fsi_bit_bang-0/fsi_bit_bang.fsi_enable</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/fsi_bit_bang-0/fsi_bit_bang.fsi_mux</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/boxconn-6/boxelder-1/fsi_bit_bang-0/fsi_bit_bang.fsi_trans</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>DRIVER_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>GPIO_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>PIN_NAME</id>
+	<value></value>
+	</property>
+	<property>
+	<id>POR_VALUE</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -6541,30 +6846,11 @@
 	</property>
 	<property>
 	<id>LED_TYPE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/rear-fault-led-0</id>
-	<property>
-	<id>BLINK_RATE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>FUNCTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>LED_TYPE</id>
 	<value>ENC-FAULT</value>
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/rear-fault-led-0/led_enable</id>
+	<id>/sys-0/node-0/motherboard-0/rear-fault-0/led_enable</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -6587,7 +6873,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/rear-id-led-1</id>
+	<id>/sys-0/node-0/motherboard-0/rear-id-1</id>
 	<property>
 	<id>BLINK_RATE</id>
 	<value></value>
@@ -6606,7 +6892,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/rear-id-led-1/led_enable</id>
+	<id>/sys-0/node-0/motherboard-0/rear-id-1/led_enable</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -6629,7 +6915,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/rear-power-led-2</id>
+	<id>/sys-0/node-0/motherboard-0/rear-power-2</id>
 	<property>
 	<id>BLINK_RATE</id>
 	<value></value>
@@ -6648,7 +6934,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/rear-power-led-2/led_enable</id>
+	<id>/sys-0/node-0/motherboard-0/rear-power-2/led_enable</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -7363,7 +7649,22 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/teakconn-7/teak-2/front-fault-led-4/led_enable</id>
+	<id>/sys-0/node-0/motherboard-0/teakconn-7/teak-2/front-fault-4</id>
+	<property>
+	<id>BLINK_RATE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>FUNCTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>LED_TYPE</id>
+	<value>ENC-FAULT</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/teakconn-7/teak-2/front-fault-4/led_enable</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -7386,7 +7687,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/teakconn-7/teak-2/front-id-led-5/led_enable</id>
+	<id>/sys-0/node-0/motherboard-0/teakconn-7/teak-2/front-id-5/led_enable</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -7409,7 +7710,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/teakconn-7/teak-2/front-power-led-3</id>
+	<id>/sys-0/node-0/motherboard-0/teakconn-7/teak-2/front-power-3</id>
 	<property>
 	<id>BLINK_RATE</id>
 	<value></value>
@@ -7428,7 +7729,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/teakconn-7/teak-2/front-power-led-3/led_enable</id>
+	<id>/sys-0/node-0/motherboard-0/teakconn-7/teak-2/front-power-3/led_enable</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -11001,9 +11302,9 @@
 	<child_id>planar_vpd-0</child_id>
 	<child_id>boxconn-6</child_id>
 	<child_id>teakconn-7</child_id>
-	<child_id>rear-fault-led-0</child_id>
-	<child_id>rear-id-led-1</child_id>
-	<child_id>rear-power-led-2</child_id>
+	<child_id>rear-fault-0</child_id>
+	<child_id>rear-id-1</child_id>
+	<child_id>rear-power-2</child_id>
 	<child_id>UCD90160-0</child_id>
 	<child_id>PCA9552-0</child_id>
 	<child_id>TMP423A-0</child_id>
@@ -11345,12 +11646,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_V3_gpion2_pwm2/chip-bmc-ast2500.pingroup_gpion2/chip-bmc-ast2500.GPION2 => rear-fault-led-0/led_enable</bus_id>
+		<bus_id>boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_V3_gpion2_pwm2/chip-bmc-ast2500.pingroup_gpion2/chip-bmc-ast2500.GPION2 => rear-fault-0/led_enable</bus_id>
 		<bus_type>GPIO</bus_type>
 		<cable>no</cable>
 		<source_path>boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_V3_gpion2_pwm2/chip-bmc-ast2500.pingroup_gpion2/</source_path>
 		<source_target>chip-bmc-ast2500.GPION2</source_target>
-		<dest_path>rear-fault-led-0/</dest_path>
+		<dest_path>rear-fault-0/</dest_path>
 		<dest_target>led_enable</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -11362,12 +11663,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_W3_gpion4_pwm4/chip-bmc-ast2500.pingroup_gpion4/chip-bmc-ast2500.GPION4 => rear-id-led-1/led_enable</bus_id>
+		<bus_id>boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_W3_gpion4_pwm4/chip-bmc-ast2500.pingroup_gpion4/chip-bmc-ast2500.GPION4 => rear-id-1/led_enable</bus_id>
 		<bus_type>GPIO</bus_type>
 		<cable>no</cable>
 		<source_path>boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_W3_gpion4_pwm4/chip-bmc-ast2500.pingroup_gpion4/</source_path>
 		<source_target>chip-bmc-ast2500.GPION4</source_target>
-		<dest_path>rear-id-led-1/</dest_path>
+		<dest_path>rear-id-1/</dest_path>
 		<dest_target>led_enable</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -11379,12 +11680,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_U3_gpion3_pwm3/chip-bmc-ast2500.pingroup_gpion3/chip-bmc-ast2500.GPION3 => rear-power-led-2/led_enable</bus_id>
+		<bus_id>boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_U3_gpion3_pwm3/chip-bmc-ast2500.pingroup_gpion3/chip-bmc-ast2500.GPION3 => rear-power-2/led_enable</bus_id>
 		<bus_type>GPIO</bus_type>
 		<cable>no</cable>
 		<source_path>boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_U3_gpion3_pwm3/chip-bmc-ast2500.pingroup_gpion3/</source_path>
 		<source_target>chip-bmc-ast2500.GPION3</source_target>
-		<dest_path>rear-power-led-2/</dest_path>
+		<dest_path>rear-power-2/</dest_path>
 		<dest_target>led_enable</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -21867,8 +22168,8 @@
 		<default>0,0,0,0</default>
 	</attribute>
 	<attribute>
-        <id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
-        <default>0x0000,0x0000,0x0000,0x0000</default>
+		<id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
+		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21896,8 +22197,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-        <id>PROC_PCIE_LANE_MASK</id>
-        <default>0x0000,0x0000,0x0000,0x0000</default>
+		<id>PROC_PCIE_LANE_MASK</id>
+		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PROC_PCIE_PCS_M_CNTL</id>
@@ -22525,7 +22826,7 @@
 	</attribute>
 	<attribute>
 		<id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
-        <default>0x0000,0x0000,0x0000,0x0000</default>
+		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -22554,7 +22855,7 @@
 	</attribute>
 	<attribute>
 		<id>PROC_PCIE_LANE_MASK</id>
-        <default>0x0000,0x0000,0x0000,0x0000</default>
+		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PROC_PCIE_PCS_M_CNTL</id>
@@ -23486,7 +23787,7 @@
 	</attribute>
 	<attribute>
 		<id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
-        <default>0x0000,0x0000,0x0000,0x0000</default>
+		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23515,7 +23816,7 @@
 	</attribute>
 	<attribute>
 		<id>PROC_PCIE_LANE_MASK</id>
-        <default>0x0000,0x0000,0x0000,0x0000</default>
+		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PROC_PCIE_PCS_M_CNTL</id>
@@ -47798,6 +48099,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
 		<id>MODEL</id>
 		<default></default>
 	</attribute>
@@ -49576,6 +49881,7 @@
 	<child_id>BCM5719-0</child_id>
 	<child_id>RS232connector-0</child_id>
 	<child_id>bmcserialconnector-1</child_id>
+	<child_id>fsi_bit_bang-0</child_id>
 	<attribute>
 		<id>CARD_TYPE</id>
 		<default></default>
@@ -49624,6 +49930,91 @@
 		<source_target>chip-bmc-ast2500.RMII1</source_target>
 		<dest_path>BCM5719-0/</dest_path>
 		<dest_target>BCM5719.port0</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>bmc-0/chip-bmc-ast2500.pin_Y21_gpioaa0/chip-bmc-ast2500.pingroup_gpioaa0/chip-bmc-ast2500.GPIOAA0 => fsi_bit_bang-0/fsi_bit_bang.fsi_clk-0</bus_id>
+		<bus_type>GPIO</bus_type>
+		<cable>no</cable>
+		<source_path>bmc-0/chip-bmc-ast2500.pin_Y21_gpioaa0/chip-bmc-ast2500.pingroup_gpioaa0/</source_path>
+		<source_target>chip-bmc-ast2500.GPIOAA0</source_target>
+		<dest_path>fsi_bit_bang-0/</dest_path>
+		<dest_target>fsi_bit_bang.fsi_clk-0</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>1</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>bmc-0/chip-bmc-ast2500.pin_B20_gpioe0e7_uart3/chip-bmc-ast2500.pingroup_gpioe0e7/chip-bmc-ast2500.GPIOE0 => fsi_bit_bang-0/fsi_bit_bang.fsi_dat-1</bus_id>
+		<bus_type>GPIO</bus_type>
+		<cable>no</cable>
+		<source_path>bmc-0/chip-bmc-ast2500.pin_B20_gpioe0e7_uart3/chip-bmc-ast2500.pingroup_gpioe0e7/</source_path>
+		<source_target>chip-bmc-ast2500.GPIOE0</source_target>
+		<dest_path>fsi_bit_bang-0/</dest_path>
+		<dest_target>fsi_bit_bang.fsi_dat-1</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>1</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>bmc-0/chip-bmc-ast2500.pin_F19_gpiod0d7_sd/chip-bmc-ast2500.pingroup_gpiod0d7/chip-bmc-ast2500.GPIOD0 => fsi_bit_bang-0/fsi_bit_bang.fsi_enable</bus_id>
+		<bus_type>GPIO</bus_type>
+		<cable>no</cable>
+		<source_path>bmc-0/chip-bmc-ast2500.pin_F19_gpiod0d7_sd/chip-bmc-ast2500.pingroup_gpiod0d7/</source_path>
+		<source_target>chip-bmc-ast2500.GPIOD0</source_target>
+		<dest_path>fsi_bit_bang-0/</dest_path>
+		<dest_target>fsi_bit_bang.fsi_enable</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>1</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>bmc-0/chip-bmc-ast2500.pin_C13_gpioa6_timer7/chip-bmc-ast2500.pingroup_gpioa6/chip-bmc-ast2500.GPIOA6 => fsi_bit_bang-0/fsi_bit_bang.fsi_mux</bus_id>
+		<bus_type>GPIO</bus_type>
+		<cable>no</cable>
+		<source_path>bmc-0/chip-bmc-ast2500.pin_C13_gpioa6_timer7/chip-bmc-ast2500.pingroup_gpioa6/</source_path>
+		<source_target>chip-bmc-ast2500.GPIOA6</source_target>
+		<dest_path>fsi_bit_bang-0/</dest_path>
+		<dest_target>fsi_bit_bang.fsi_mux</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>1</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>bmc-0/chip-bmc-ast2500.pin_T17_gpior2r5_spi2/chip-bmc-ast2500.pingroup_gpior2r5/chip-bmc-ast2500.GPIOR2 => fsi_bit_bang-0/fsi_bit_bang.fsi_trans</bus_id>
+		<bus_type>GPIO</bus_type>
+		<cable>no</cable>
+		<source_path>bmc-0/chip-bmc-ast2500.pin_T17_gpior2r5_spi2/chip-bmc-ast2500.pingroup_gpior2r5/</source_path>
+		<source_target>chip-bmc-ast2500.GPIOR2</source_target>
+		<dest_path>fsi_bit_bang-0/</dest_path>
+		<dest_target>fsi_bit_bang.fsi_trans</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>1</default>
+		</bus_attribute>
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
@@ -108567,16 +108958,8 @@
 	<instance_name>BMC_FLASH.spi-slave</instance_name>
 	<position>0</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>SPI</default>
-	</attribute>
-	<attribute>
-		<id>CHIPLET_ID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -108587,80 +108970,16 @@
 		<default>UNIT</default>
 	</attribute>
 	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>DIRECTION</id>
 		<default>IN</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value>1</value></field>
-				<field><id>supportsXscom</id><value>1</value></field>
-				<field><id>supportsInbandScom</id><value>0</value></field>
-				<field><id>reserved</id><value>0</value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -108954,16 +109273,8 @@
 	<instance_name>PNOR_FLASH.spi-slave</instance_name>
 	<position>0</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>SPI</default>
-	</attribute>
-	<attribute>
-		<id>CHIPLET_ID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>CHIP_UNIT</id>
@@ -108974,80 +109285,16 @@
 		<default>UNIT</default>
 	</attribute>
 	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>DIRECTION</id>
 		<default>IN</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value>1</value></field>
-				<field><id>supportsXscom</id><value>1</value></field>
-				<field><id>supportsInbandScom</id><value>0</value></field>
-				<field><id>reserved</id><value>0</value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -109721,6 +109968,596 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
+	<id>fsi_bit_bang-0</id>
+	<type>chip-fsi_bit_bang</type>
+	<is_root>false</is_root>
+	<instance_name>fsi_bit_bang</instance_name>
+	<position>0</position>
+	<child_id>fsi_bit_bang.fsi_clk-0</child_id>
+	<child_id>fsi_bit_bang.fsi_dat-1</child_id>
+	<child_id>fsi_bit_bang.fsi_master-0</child_id>
+	<child_id>fsi_bit_bang.fsi_mux</child_id>
+	<child_id>fsi_bit_bang.fsi_enable</child_id>
+	<child_id>fsi_bit_bang.fsi_trans</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>ALTFSI_MASTER_CHIP</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>ALTFSI_MASTER_PORT</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CHIP_ID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CHIP</default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>EC</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FRU_ID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FSI_MASTER_CHIP</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FSI_MASTER_PORT</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FSI_MASTER_TYPE</id>
+		<default>NO_MASTER</default>
+	</attribute>
+	<attribute>
+		<id>FSI_OPTION_FLAGS</id>
+		<default>
+				<field><id>flipPort</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>FSI_SLAVE_CASCADE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRU_ID</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RU_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default></default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>fsi_bit_bang.fsi_clk-0</id>
+	<type>unit-gpio-generic</type>
+	<is_root>false</is_root>
+	<instance_name>fsi_bit_bang.fsi_clk</instance_name>
+	<position>0</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>GPIO</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>DRIVER_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ENGINE</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>GPIO_TYPE</id>
+		<default>GENERIC_OUTPUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NUM</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POR_VALUE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>SCHEMATIC_INTERFACE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>fsi_bit_bang.fsi_dat-1</id>
+	<type>unit-gpio-generic</type>
+	<is_root>false</is_root>
+	<instance_name>fsi_bit_bang.fsi_dat</instance_name>
+	<position>1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>GPIO</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>DRIVER_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ENGINE</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>GPIO_TYPE</id>
+		<default>GENERIC_OUTPUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NUM</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POR_VALUE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>SCHEMATIC_INTERFACE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>fsi_bit_bang.fsi_master-0</id>
+	<type>unit-fsi-master</type>
+	<is_root>false</is_root>
+	<instance_name>fsi_bit_bang.fsi_master</instance_name>
+	<position>0</position>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>FSIM</default>
+	</attribute>
+	<attribute>
+		<id>CHIPLET_ID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>CMFSI</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>OUT</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FSI_ENGINE</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>FSI_LINK</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>FSI_PORT</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRU_ID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>FSIM</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value>1</value></field>
+				<field><id>supportsXscom</id><value>1</value></field>
+				<field><id>supportsInbandScom</id><value>0</value></field>
+				<field><id>reserved</id><value>0</value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>REL_POS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>FSI</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>fsi_bit_bang.fsi_mux</id>
+	<type>unit-gpio-generic</type>
+	<is_root>false</is_root>
+	<instance_name>fsi_bit_bang.fsi_mux</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>GPIO</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>DRIVER_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ENGINE</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>GPIO_TYPE</id>
+		<default>GENERIC_OUTPUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NUM</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POR_VALUE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>SCHEMATIC_INTERFACE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>fsi_bit_bang.fsi_enable</id>
+	<type>unit-gpio-generic</type>
+	<is_root>false</is_root>
+	<instance_name>fsi_bit_bang.fsi_enable</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>GPIO</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>DRIVER_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ENGINE</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>GPIO_TYPE</id>
+		<default>GENERIC_OUTPUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NUM</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POR_VALUE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>SCHEMATIC_INTERFACE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>fsi_bit_bang.fsi_trans</id>
+	<type>unit-gpio-generic</type>
+	<is_root>false</is_root>
+	<instance_name>fsi_bit_bang.fsi_trans</instance_name>
+	<position>-1</position>
+	<attribute>
+		<id>BUS_TYPE</id>
+		<default>GPIO</default>
+	</attribute>
+	<attribute>
+		<id>CHIP_UNIT</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>UNIT</default>
+	</attribute>
+	<attribute>
+		<id>DIRECTION</id>
+		<default>IN</default>
+	</attribute>
+	<attribute>
+		<id>DRIVER_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ENGINE</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>GPIO_TYPE</id>
+		<default>GENERIC_OUTPUT</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NAME</id>
+		<default>
+				<field><id>Value</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>PIN_NUM</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POR_VALUE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>SCHEMATIC_INTERFACE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
 	<id>teakconn-7</id>
 	<type>connector-card-generic</type>
 	<is_root>false</is_root>
@@ -109766,9 +110603,9 @@
 	<child_id>MAX31785-0</child_id>
 	<child_id>BMP280-0</child_id>
 	<child_id>PCA9552-1</child_id>
-	<child_id>front-power-led-3</child_id>
-	<child_id>front-fault-led-4</child_id>
-	<child_id>front-id-led-5</child_id>
+	<child_id>front-power-3</child_id>
+	<child_id>front-fault-4</child_id>
+	<child_id>front-id-5</child_id>
 	<child_id>fanconn-10</child_id>
 	<child_id>fanconn-11</child_id>
 	<child_id>fanconn-12</child_id>
@@ -109882,12 +110719,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>PCA9552-1/PCA9552.gpio-13 => front-fault-led-4/led_enable</bus_id>
+		<bus_id>PCA9552-1/PCA9552.gpio-13 => front-fault-4/led_enable</bus_id>
 		<bus_type>GPIO</bus_type>
 		<cable>no</cable>
 		<source_path>PCA9552-1/</source_path>
 		<source_target>PCA9552.gpio-13</source_target>
-		<dest_path>front-fault-led-4/</dest_path>
+		<dest_path>front-fault-4/</dest_path>
 		<dest_target>led_enable</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -109899,12 +110736,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>PCA9552-1/PCA9552.gpio-14 => front-power-led-3/led_enable</bus_id>
+		<bus_id>PCA9552-1/PCA9552.gpio-14 => front-power-3/led_enable</bus_id>
 		<bus_type>GPIO</bus_type>
 		<cable>no</cable>
 		<source_path>PCA9552-1/</source_path>
 		<source_target>PCA9552.gpio-14</source_target>
-		<dest_path>front-power-led-3/</dest_path>
+		<dest_path>front-power-3/</dest_path>
 		<dest_target>led_enable</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -109916,12 +110753,12 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>PCA9552-1/PCA9552.gpio-15 => front-id-led-5/led_enable</bus_id>
+		<bus_id>PCA9552-1/PCA9552.gpio-15 => front-id-5/led_enable</bus_id>
 		<bus_type>GPIO</bus_type>
 		<cable>no</cable>
 		<source_path>PCA9552-1/</source_path>
 		<source_target>PCA9552.gpio-15</source_target>
-		<dest_path>front-id-led-5/</dest_path>
+		<dest_path>front-id-5/</dest_path>
 		<dest_target>led_enable</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -112957,10 +113794,10 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>front-power-led-3</id>
+	<id>front-power-3</id>
 	<type>led-led-generic</type>
 	<is_root>false</is_root>
-	<instance_name>front-power-led</instance_name>
+	<instance_name>front-power</instance_name>
 	<position>3</position>
 	<child_id>led_enable</child_id>
 	<child_id>generic-logic-assoc</child_id>
@@ -113131,10 +113968,10 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>front-fault-led-4</id>
+	<id>front-fault-4</id>
 	<type>led-led-generic</type>
 	<is_root>false</is_root>
-	<instance_name>front-fault-led</instance_name>
+	<instance_name>front-fault</instance_name>
 	<position>4</position>
 	<child_id>led_enable</child_id>
 	<child_id>generic-logic-assoc</child_id>
@@ -113204,10 +114041,10 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>front-id-led-5</id>
+	<id>front-id-5</id>
 	<type>led-led-generic</type>
 	<is_root>false</is_root>
-	<instance_name>front-id-led</instance_name>
+	<instance_name>front-id</instance_name>
 	<position>5</position>
 	<child_id>led_enable</child_id>
 	<child_id>generic-logic-assoc</child_id>
@@ -113226,10 +114063,10 @@
 	<attribute>
 		<id>CONTROL_GROUPS</id>
 		<default>EnclosureIdentify,1,50,
-        Fan0Identify,1,50,
-        Fan1Identify,1,50,
-        Fan2Identify,1,50,
-        Fan3Identify,1,50,
+        Fan0Identify,0,50,
+        Fan1Identify,0,50,
+        Fan2Identify,0,50,
+        Fan3Identify,0,50,
         NA,0,50,
         NA,0,50,
         NA,0,50,
@@ -114120,10 +114957,10 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>rear-fault-led-0</id>
+	<id>rear-fault-0</id>
 	<type>led-led-generic</type>
 	<is_root>false</is_root>
-	<instance_name>rear-fault-led</instance_name>
+	<instance_name>rear-fault</instance_name>
 	<position>0</position>
 	<child_id>led_enable</child_id>
 	<child_id>generic-logic-assoc</child_id>
@@ -114193,10 +115030,10 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>rear-id-led-1</id>
+	<id>rear-id-1</id>
 	<type>led-led-generic</type>
 	<is_root>false</is_root>
-	<instance_name>rear-id-led</instance_name>
+	<instance_name>rear-id</instance_name>
 	<position>1</position>
 	<child_id>led_enable</child_id>
 	<child_id>generic-logic-assoc</child_id>
@@ -114215,10 +115052,10 @@
 	<attribute>
 		<id>CONTROL_GROUPS</id>
 		<default>EnclosureIdentify,1,50,
-        Fan0Identify,1,50,
-        Fan1Identify,1,50,
-        Fan2Identify,1,50,
-        Fan3Identify,1,50,
+        Fan0Identify,0,50,
+        Fan1Identify,0,50,
+        Fan2Identify,0,50,
+        Fan3Identify,0,50,
         NA,0,50,
         NA,0,50,
         NA,0,50,
@@ -114270,10 +115107,10 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>rear-power-led-2</id>
+	<id>rear-power-2</id>
 	<type>led-led-generic</type>
 	<is_root>false</is_root>
-	<instance_name>rear-power-led</instance_name>
+	<instance_name>rear-power</instance_name>
 	<position>2</position>
 	<child_id>led_enable</child_id>
 	<child_id>generic-logic-assoc</child_id>


### PR DESCRIPTION
The OpenBMC FSI device driver needs to know which BMC GPIOs are
wired to which FSI related functions, like data, clock, mux, etc.
So, an fsi_bit_bang part which has specifically named gpio slave units
will accept the GPIOs from the BMC, and then has an fsi-master unit
that can be wired to the processor's fsi-slave.

In this commit also made a few very minor LED management fixes.