### PR TITLE
Fix LED priority for front/rear power LEDs

### DIFF
--- a/witherspoon.xml
+++ b/witherspoon.xml
@@ -103285,7 +103285,7 @@
 	</attribute>
 	<attribute>
 		<id>LED_PRIORITY</id>
-		<default>BLINK</default>
+		<default>ON</default>
 	</attribute>
 	<attribute>
 		<id>LED_TYPE</id>
@@ -105087,7 +105087,7 @@
 	</attribute>
 	<attribute>
 		<id>LED_PRIORITY</id>
-		<default>BLINK</default>
+		<default>ON</default>
 	</attribute>
 	<attribute>
 		<id>LED_TYPE</id>


### PR DESCRIPTION
They should be set to ON so OpenBMC code can treat them differently than the standard fault/ID LEDs.