### PR TITLE
Changing SUPPORTED_STOP_STATES to allow stop1 , stop2 and stop4

### DIFF
--- a/witherspoon.xml
+++ b/witherspoon.xml
@@ -14188,7 +14188,7 @@
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_STOP_STATES</id>
-		<default>0x80000000</default>
+		<default>0xE8000000</default>
 	</attribute>
 	<attribute>
 		<id>SUPPORTS_DYNAMIC_MEM_VOLT</id>


### PR DESCRIPTION
Changing stop-enabled to allow stop1 , stop2 and stop4.

Signed-off-by: Akshay Adiga <akshay.adiga@linux.vnet.ibm.com>