### PR TITLE
sync with common_mrw_xml -- 09/07

### DIFF
--- a/witherspoon.xml
+++ b/witherspoon.xml
@@ -1,5 +1,5 @@
 <systemInstance>
-<version>2.2</version>
+<version>2.10</version>
 <enumerationTypes>
 <enumerationType>
 	<id>ASSOCIATION_TYPE</id>
@@ -331,6 +331,1379 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>CEN_EFF_CEN_DRV_IMP_DQ_DQS</id>
+		<enumerator>
+		<name>OHM40_FFE240</name>
+		<value>0x36</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40_FFE120</name>
+		<value>0x16</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE240</name>
+		<value>0x38</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM24_FFE0</name>
+		<value>0x0A</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE480</name>
+		<value>0x48</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE160</name>
+		<value>0x28</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE160</name>
+		<value>0x27</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE480</name>
+		<value>0x47</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE120</name>
+		<value>0x18</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE240</name>
+		<value>0x37</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE0</name>
+		<value>0x07</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE120</name>
+		<value>0x17</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40_FFE160</name>
+		<value>0x26</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40_FFE480</name>
+		<value>0x46</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40_FFE0</name>
+		<value>0x06</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE0</name>
+		<value>0x08</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_EFF_CEN_RCV_IMP_DQ_DQS</id>
+		<enumerator>
+		<name>OHM120</name>
+		<value>120</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM15</name>
+		<value>15</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM48</name>
+		<value>48</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM240</name>
+		<value>240</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM60</name>
+		<value>60</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM80</name>
+		<value>80</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM20</name>
+		<value>20</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30</name>
+		<value>30</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40</name>
+		<value>40</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM160</name>
+		<value>160</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_EFF_CEN_SLEW_RATE_DQ_DQS</id>
+		<enumerator>
+		<name>SLEW_5V_NS</name>
+		<value>5</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_MAXV_NS</name>
+		<value>7</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_6V_NS</name>
+		<value>6</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_3V_NS</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_4V_NS</name>
+		<value>4</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_EFF_DRAM_WR_VREF</id>
+		<enumerator>
+		<name>VDD565</name>
+		<value>565</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD445</name>
+		<value>445</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD500</name>
+		<value>500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD420</name>
+		<value>420</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD465</name>
+		<value>465</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD520</name>
+		<value>520</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD440</name>
+		<value>440</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD485</name>
+		<value>485</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD540</name>
+		<value>540</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD460</name>
+		<value>460</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD560</name>
+		<value>560</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD480</name>
+		<value>480</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD515</name>
+		<value>515</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD435</name>
+		<value>435</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD535</name>
+		<value>535</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD455</name>
+		<value>455</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD510</name>
+		<value>510</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD555</name>
+		<value>555</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD475</name>
+		<value>475</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD530</name>
+		<value>530</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD575</name>
+		<value>575</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD495</name>
+		<value>495</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD550</name>
+		<value>550</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD430</name>
+		<value>430</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD570</name>
+		<value>570</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD450</name>
+		<value>450</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD470</name>
+		<value>470</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD490</name>
+		<value>490</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD505</name>
+		<value>505</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD525</name>
+		<value>525</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD545</name>
+		<value>545</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD425</name>
+		<value>425</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_EFF_RD_VREF</id>
+		<enumerator>
+		<name>VDD78250</name>
+		<value>78250</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD81000</name>
+		<value>81000</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD54125</name>
+		<value>54125</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD64500</name>
+		<value>64500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD51375</name>
+		<value>51375</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD61750</name>
+		<value>61750</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD50000</name>
+		<value>50000</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD68625</name>
+		<value>68625</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD65875</name>
+		<value>65875</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD48625</name>
+		<value>48625</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD70000</name>
+		<value>70000</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD45875</name>
+		<value>45875</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD44500</name>
+		<value>44500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD74125</name>
+		<value>74125</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD41750</name>
+		<value>41750</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD71375</name>
+		<value>71375</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD47250</name>
+		<value>47250</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD61000</name>
+		<value>61000</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD59625</name>
+		<value>59625</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD60375</name>
+		<value>60375</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD55500</name>
+		<value>55500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD56875</name>
+		<value>56875</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD63125</name>
+		<value>63125</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD52750</name>
+		<value>52750</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD58250</name>
+		<value>58250</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD43125</name>
+		<value>43125</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD72750</name>
+		<value>72750</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD40375</name>
+		<value>40375</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD75500</name>
+		<value>75500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD76875</name>
+		<value>76875</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD79625</name>
+		<value>79625</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD67250</name>
+		<value>67250</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MRW_CDIMM_MASTER_I2C_TEMP_SENSOR_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MRW_CDIMM_SPARE_I2C_TEMP_SENSOR_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MRW_MBA_CACHELINE_INTERLEAVE_MODE_CONTROL</id>
+		<enumerator>
+		<name>NEVER</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>REQUIRED</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>REQUESTED</name>
+		<value>2</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MRW_POWER_CONTROL_REQUESTED</id>
+		<enumerator>
+		<name>FASTEXIT</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>SLOWEXIT</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MRW_STRICT_MBA_PLUG_RULE_CHECKING</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MSS_ALLOW_SINGLE_PORT</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MSS_CACHE_ENABLE</id>
+		<enumerator>
+		<name>HALF_A</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>HALF_B</name>
+		<value>5</value>
+		</enumerator>
+		<enumerator>
+		<name>UNK_ON</name>
+		<value>9</value>
+		</enumerator>
+		<enumerator>
+		<name>UNK_OFF</name>
+		<value>8</value>
+		</enumerator>
+		<enumerator>
+		<name>UNK_HALF_B</name>
+		<value>0xD</value>
+		</enumerator>
+		<enumerator>
+		<name>UNK_HALF_A</name>
+		<value>0xB</value>
+		</enumerator>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MSS_CLEANER_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MSS_DQS_SWIZZLE_TYPE</id>
+		<enumerator>
+		<name>NORMAL_TYPE_0</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ISDIMM_TYPE_2</name>
+		<value>2</value>
+		</enumerator>
+		<enumerator>
+		<name>GLACIER_TYPE_1</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MSS_DRAMINIT_RESET_DISABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MSS_FREQ_OVERRIDE</id>
+		<enumerator>
+		<name>AUTO</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MSS_PREFETCH_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MSS_VOLT_COMPLIANT_DIMMS</id>
+		<enumerator>
+		<name>ALL_VOLTAGES</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>PROCEDURE_DEFINED</name>
+		<value>0x00</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_MSS_VOLT_OVERRIDE</id>
+		<enumerator>
+		<name>VOLT_135</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>NONE</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>VOLT_120</name>
+		<value>0x02</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DIMM_RCD_OUTPUT_TIMING</id>
+		<enumerator>
+		<name>3T</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>1T</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DIMM_SPARE</id>
+		<enumerator>
+		<name>LOW_NIBBLE</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>HIGH_NIBBLE</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>NO_SPARE</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>FULL_BYTE</name>
+		<value>0x03</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRAM_2N_MODE_ENABLED</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRAM_ADDRESS_MIRRORING</id>
+		<enumerator>
+		<name>RANK1_MIRRORED</name>
+		<value>0x04</value>
+		</enumerator>
+		<enumerator>
+		<name>RANK2_MIRRORED</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>RANK0_MIRRORED</name>
+		<value>0x08</value>
+		</enumerator>
+		<enumerator>
+		<name>RANK3_MIRRORED</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRAM_RON</id>
+		<enumerator>
+		<name>OHM48</name>
+		<value>48</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40</name>
+		<value>40</value>
+		</enumerator>
+		<enumerator>
+		<name>INVALID</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34</name>
+		<value>34</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRAM_RTT_NOM</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM120</name>
+		<value>120</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM48</name>
+		<value>48</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM240</name>
+		<value>240</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM60</name>
+		<value>60</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM80</name>
+		<value>80</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM20</name>
+		<value>20</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30</name>
+		<value>30</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40</name>
+		<value>40</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34</name>
+		<value>34</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRAM_RTT_PARK</id>
+		<enumerator>
+		<name>120OHM</name>
+		<value>120</value>
+		</enumerator>
+		<enumerator>
+		<name>240OHM</name>
+		<value>240</value>
+		</enumerator>
+		<enumerator>
+		<name>80OHM</name>
+		<value>80</value>
+		</enumerator>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>34OHM</name>
+		<value>34</value>
+		</enumerator>
+		<enumerator>
+		<name>60OHM</name>
+		<value>60</value>
+		</enumerator>
+		<enumerator>
+		<name>48OHM</name>
+		<value>48</value>
+		</enumerator>
+		<enumerator>
+		<name>40OHM</name>
+		<value>40</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRAM_RTT_WR</id>
+		<enumerator>
+		<name>HIGHZ</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM120</name>
+		<value>120</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM240</name>
+		<value>240</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM60</name>
+		<value>60</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRAM_WR_VREF</id>
+		<enumerator>
+		<name>VDD565</name>
+		<value>565</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD445</name>
+		<value>445</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD500</name>
+		<value>500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD420</name>
+		<value>420</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD465</name>
+		<value>465</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD520</name>
+		<value>520</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD440</name>
+		<value>440</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD485</name>
+		<value>485</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD540</name>
+		<value>540</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD460</name>
+		<value>460</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD560</name>
+		<value>560</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD480</name>
+		<value>480</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD515</name>
+		<value>515</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD435</name>
+		<value>435</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD535</name>
+		<value>535</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD455</name>
+		<value>455</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD510</name>
+		<value>510</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD555</name>
+		<value>555</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD475</name>
+		<value>475</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD530</name>
+		<value>530</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD575</name>
+		<value>575</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD495</name>
+		<value>495</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD550</name>
+		<value>550</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD430</name>
+		<value>430</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD570</name>
+		<value>570</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD450</name>
+		<value>450</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD470</name>
+		<value>470</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD490</name>
+		<value>490</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD505</name>
+		<value>505</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD525</name>
+		<value>525</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD545</name>
+		<value>545</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD425</name>
+		<value>425</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRV_IMP_ADDR</id>
+		<enumerator>
+		<name>OHM15</name>
+		<value>15</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM20</name>
+		<value>20</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30</name>
+		<value>30</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40</name>
+		<value>40</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRV_IMP_CLK</id>
+		<enumerator>
+		<name>OHM15</name>
+		<value>15</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM20</name>
+		<value>20</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30</name>
+		<value>30</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40</name>
+		<value>40</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRV_IMP_CNTL</id>
+		<enumerator>
+		<name>OHM15</name>
+		<value>15</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM20</name>
+		<value>20</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30</name>
+		<value>30</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40</name>
+		<value>40</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRV_IMP_DQ_DQS</id>
+		<enumerator>
+		<name>OHM40_FFE240</name>
+		<value>0x36</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40_FFE120</name>
+		<value>0x16</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE240</name>
+		<value>0x38</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM24_FFE0</name>
+		<value>0x0A</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE480</name>
+		<value>0x48</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE160</name>
+		<value>0x28</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE160</name>
+		<value>0x27</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE480</name>
+		<value>0x47</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE120</name>
+		<value>0x18</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE240</name>
+		<value>0x37</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE0</name>
+		<value>0x07</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM34_FFE120</name>
+		<value>0x17</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40_FFE160</name>
+		<value>0x26</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40_FFE480</name>
+		<value>0x46</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40_FFE0</name>
+		<value>0x06</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30_FFE0</name>
+		<value>0x08</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_DRV_IMP_SPCKE</id>
+		<enumerator>
+		<name>OHM15</name>
+		<value>15</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM20</name>
+		<value>20</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30</name>
+		<value>30</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40</name>
+		<value>40</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_POWER_CONTROL_CAPABLE</id>
+		<enumerator>
+		<name>FASTSLOW_CAPABLE</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>SLOWEXIT_CAPABLE</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>FASTEXIT_CAPABLE</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>NONE</name>
+		<value>0x00</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_RCV_IMP_DQ_DQS</id>
+		<enumerator>
+		<name>OHM120</name>
+		<value>120</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM15</name>
+		<value>15</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM48</name>
+		<value>48</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM240</name>
+		<value>240</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM60</name>
+		<value>60</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM80</name>
+		<value>80</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM20</name>
+		<value>20</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM30</name>
+		<value>30</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM40</name>
+		<value>40</value>
+		</enumerator>
+		<enumerator>
+		<name>OHM160</name>
+		<value>160</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_RD_VREF</id>
+		<enumerator>
+		<name>VDD78250</name>
+		<value>78250</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD81000</name>
+		<value>81000</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD54125</name>
+		<value>54125</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD64500</name>
+		<value>64500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD51375</name>
+		<value>51375</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD61750</name>
+		<value>61750</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD50000</name>
+		<value>50000</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD68625</name>
+		<value>68625</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD65875</name>
+		<value>65875</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD48625</name>
+		<value>48625</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD70000</name>
+		<value>70000</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD45875</name>
+		<value>45875</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD44500</name>
+		<value>44500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD74125</name>
+		<value>74125</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD41750</name>
+		<value>41750</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD71375</name>
+		<value>71375</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD47250</name>
+		<value>47250</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD61000</name>
+		<value>61000</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD59625</name>
+		<value>59625</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD60375</name>
+		<value>60375</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD55500</name>
+		<value>55500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD56875</name>
+		<value>56875</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD63125</name>
+		<value>63125</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD52750</name>
+		<value>52750</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD58250</name>
+		<value>58250</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD43125</name>
+		<value>43125</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD72750</name>
+		<value>72750</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD40375</name>
+		<value>40375</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD75500</name>
+		<value>75500</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD76875</name>
+		<value>76875</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD79625</name>
+		<value>79625</value>
+		</enumerator>
+		<enumerator>
+		<name>VDD67250</name>
+		<value>67250</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_SLEW_RATE_ADDR</id>
+		<enumerator>
+		<name>SLEW_5V_NS</name>
+		<value>5</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_MAXV_NS</name>
+		<value>7</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_6V_NS</name>
+		<value>6</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_3V_NS</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_4V_NS</name>
+		<value>4</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_SLEW_RATE_CLK</id>
+		<enumerator>
+		<name>SLEW_5V_NS</name>
+		<value>5</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_MAXV_NS</name>
+		<value>7</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_6V_NS</name>
+		<value>6</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_3V_NS</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_4V_NS</name>
+		<value>4</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_SLEW_RATE_CNTL</id>
+		<enumerator>
+		<name>SLEW_5V_NS</name>
+		<value>5</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_MAXV_NS</name>
+		<value>7</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_6V_NS</name>
+		<value>6</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_3V_NS</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_4V_NS</name>
+		<value>4</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_SLEW_RATE_DQ_DQS</id>
+		<enumerator>
+		<name>SLEW_5V_NS</name>
+		<value>5</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_MAXV_NS</name>
+		<value>7</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_6V_NS</name>
+		<value>6</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_3V_NS</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_4V_NS</name>
+		<value>4</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_SLEW_RATE_SPCKE</id>
+		<enumerator>
+		<name>SLEW_5V_NS</name>
+		<value>5</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_MAXV_NS</name>
+		<value>7</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_6V_NS</name>
+		<value>6</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_3V_NS</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>SLEW_4V_NS</name>
+		<value>4</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CEN_VPD_VERSION</id>
+		<enumerator>
+		<name>UNKNOWN</name>
+		<value>0x3030</value>
+		</enumerator>
+		<enumerator>
+		<name>OLD_CDIMM</name>
+		<value>0x3031</value>
+		</enumerator>
+		<enumerator>
+		<name>CURRENT</name>
+		<value>0x3230</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>CHIP_VER</id>
 		<enumerator>
 		<name>DD10</name>
@@ -401,6 +1774,28 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>CME_CHTM_TRACE_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>CME_INSTRUCTION_TRACE_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>CONNECTOR_TYPE</id>
 		<enumerator>
 		<name>PCIE_X8_CARD</name>
@@ -460,6 +1855,28 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>CP_REFCLOCK_RCVR_TERM</id>
+		<enumerator>
+		<name>FIFTY_OHM</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>NONE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>DD1_SLOW_PCI_REF_CLOCK</id>
+		<enumerator>
+		<name>SLOW</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>NORMAL</name>
+		<value>0x00</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>DIRECTION</id>
 		<enumerator>
 		<name>INOUT</name>
@@ -479,6 +1896,51 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>DISABLE_HBBL_VECTORS</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>DMI_INBAND_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>DPLL_VDM_RESPONSE</id>
+		<enumerator>
+		<name>DYNAMIC_PROTECT</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>DROOP_PROTECT</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>NONE</name>
+		<value>0x04</value>
+		</enumerator>
+		<enumerator>
+		<name>DROOP_PROTECT_OVERVOLT</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>DYNAMIC</name>
+		<value>0x02</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>DRIVER_TYPE</id>
 		<enumerator>
 		<name>PUSH-PULL</name>
@@ -491,6 +1953,25 @@
 		<enumerator>
 		<name>OPEN-DRAIN</name>
 		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>EI_BUS_TX_MSBSWAP</id>
+		<enumerator>
+		<name>GROUP_0_SWAP</name>
+		<value>0x80</value>
+		</enumerator>
+		<enumerator>
+		<name>NO_SWAP</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>GROUP_1_SWAP</name>
+		<value>0x40</value>
+		</enumerator>
+		<enumerator>
+		<name>ALL_SWAP</name>
+		<value>0xFF</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -586,34 +2067,80 @@
 		<value>0x22</value>
 		</enumerator>
 		<enumerator>
+		<name>GPU_CORE</name>
+		<value>0xD8</value>
+		</enumerator>
+		<enumerator>
+		<name>GPU_MEMORY</name>
+		<value>0xD9</value>
+		</enumerator>
+		<enumerator>
 		<name>CHASSIS</name>
 		<value>0x17</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
-	<id>FAPI_POS</id>
+	<id>EXECUTION_PLATFORM</id>
 		<enumerator>
-		<name>NA</name>
-		<value>0xFFFFFFFF</value>
+		<name>FSP</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>HOST</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>OCC</name>
+		<value>0x03</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
-	<id>FSI_MASTER_TYPE</id>
+	<id>FREQ_PB_MHZ</id>
 		<enumerator>
-		<name>CMFSI</name>
-		<value>1</value>
+		<name>1866</name>
+		<value>1866</value>
 		</enumerator>
 		<enumerator>
-		<name>NO_MASTER</name>
-		<value>2</value>
+		<name>1600</name>
+		<value>1600</value>
 		</enumerator>
 		<enumerator>
-		<name>MFSI</name>
-		<value>0</value>
+		<name>2400</name>
+		<value>2400</value>
+		</enumerator>
+		<enumerator>
+		<name>2133</name>
+		<value>2133</value>
+		</enumerator>
+		<enumerator>
+		<name>2000</name>
+		<value>2000</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>FUNCTIONAL</id>
+		<enumerator>
+		<name>FUNCTIONAL</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>NON_FUNCTIONAL</name>
+		<value>0x0</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
 	<id>FUSED_CORE_MODE</id>
+		<enumerator>
+		<name>CORE_FUSED</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>CORE_UNFUSED</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>FUSED_CORE_MODE_HB</id>
 		<enumerator>
 		<name>SMT4_ONLY</name>
 		<value>1</value>
@@ -663,7 +2190,42 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>GPU_SENSOR_ARRAY</id>
+		<enumerator>
+		<name>FUNC_OFFSET</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>TEMP_ID_OFFSET</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>MEM_TEMP_ID_OFFSET</name>
+		<value>0x05</value>
+		</enumerator>
+		<enumerator>
+		<name>OBUS_CFG_OFFSET</name>
+		<value>0x06</value>
+		</enumerator>
+		<enumerator>
+		<name>MEM_TEMP_OFFSET</name>
+		<value>0x04</value>
+		</enumerator>
+		<enumerator>
+		<name>FUNC_ID_OFFSET</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>TEMP_OFFSET</name>
+		<value>0x02</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>HDAT_I2C_DEVICE_PURPOSE</id>
+		<enumerator>
+		<name>NVLINK_CABLE_TOPOLOGY_VERIFICATION</name>
+		<value>0xA</value>
+		</enumerator>
 		<enumerator>
 		<name>SBE_SEEPROM</name>
 		<value>0x8</value>
@@ -677,28 +2239,28 @@
 		<value>0x6</value>
 		</enumerator>
 		<enumerator>
-		<name>PCI_HOTPLUG</name>
-		<value>0xA</value>
+		<name>PCI_HOTPLUG_CONTROL</name>
+		<value>0x3</value>
 		</enumerator>
 		<enumerator>
 		<name>WINDOW_OPEN</name>
 		<value>0xD</value>
 		</enumerator>
 		<enumerator>
-		<name>CABLE_CARD_POWER_SENSE</name>
-		<value>0x2</value>
+		<name>MEX_FPGA</name>
+		<value>0xF</value>
 		</enumerator>
 		<enumerator>
 		<name>TPM</name>
 		<value>0x4</value>
 		</enumerator>
 		<enumerator>
-		<name>PLANAR_VPD</name>
-		<value>0x9</value>
+		<name>NVLINK_CABLE_MICRO_RESET</name>
+		<value>0xB</value>
 		</enumerator>
 		<enumerator>
-		<name>CABLE_CARD_POWER_CONTROL</name>
-		<value>0x3</value>
+		<name>PLANAR_VPD</name>
+		<value>0x9</value>
 		</enumerator>
 		<enumerator>
 		<name>MODULE_VPD</name>
@@ -707,6 +2269,10 @@
 		<enumerator>
 		<name>CABLE_CARD_PRES</name>
 		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>I2C_ASSOC_WITH_NVLINK_CABLE</name>
+		<value>0xC</value>
 		</enumerator>
 		<enumerator>
 		<name>NVLINK</name>
@@ -720,9 +2286,29 @@
 		<name>UNKNOWN</name>
 		<value>0xFF</value>
 		</enumerator>
+		<enumerator>
+		<name>PCI_HOTPLUG_PGOOD</name>
+		<value>0x2</value>
+		</enumerator>
 </enumerationType>
 <enumerationType>
 	<id>HDAT_I2C_DEVICE_TYPE</id>
+		<enumerator>
+		<name>9553</name>
+		<value>0x7</value>
+		</enumerator>
+		<enumerator>
+		<name>9554</name>
+		<value>0x8</value>
+		</enumerator>
+		<enumerator>
+		<name>9551</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>9552</name>
+		<value>0x6</value>
+		</enumerator>
 		<enumerator>
 		<name>955X</name>
 		<value>0x1</value>
@@ -730,6 +2316,26 @@
 		<enumerator>
 		<name>SEEPROM</name>
 		<value>0x2</value>
+		</enumerator>
+		<enumerator>
+		<name>9555</name>
+		<value>0x9</value>
+		</enumerator>
+		<enumerator>
+		<name>SEEPROM_Atmel28c128</name>
+		<value>0x2</value>
+		</enumerator>
+		<enumerator>
+		<name>MEX_FPGA</name>
+		<value>0x4</value>
+		</enumerator>
+		<enumerator>
+		<name>SEEPROM_Atmel28c256</name>
+		<value>0xB</value>
+		</enumerator>
+		<enumerator>
+		<name>SMP_or_OpenCAPI_Cable</name>
+		<value>0xA</value>
 		</enumerator>
 		<enumerator>
 		<name>NUVOTON_TPM</name>
@@ -746,10 +2352,6 @@
 		<enumerator>
 		<name>UNKNOWN</name>
 		<value>0xFF</value>
-		</enumerator>
-		<enumerator>
-		<name>MEX_FPGA</name>
-		<value>0x4</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -802,6 +2404,76 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>IO_DMI_PROC_DEBUG</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>IO_O_DEBUG</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>IO_O_MFG_CHK</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>IO_REFCLOCK_RCVR_TERM</id>
+		<enumerator>
+		<name>FIFTY_OHM</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>ONE_HUNDRED_OHM</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>NONE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>IO_X_DEBUG</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>IO_X_MFG_CHK</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>IPMI_SENSOR_ARRAY</id>
 		<enumerator>
 		<name>NAME_OFFSET</name>
@@ -810,6 +2482,39 @@
 		<enumerator>
 		<name>NUMBER_OFFSET</name>
 		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>ISTEP_MODE</id>
+		<enumerator>
+		<name>IPL</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>NON_IPL</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>IS_MPIPL</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>IS_SP_MODE</id>
+		<enumerator>
+		<name>FSP</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FSP_LESS</name>
+		<value>0x0</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -893,6 +2598,17 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>MEM_MIRROR_PLACEMENT_POLICY</id>
+		<enumerator>
+		<name>FLIPPED</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>NORMAL</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>MNFG_FLAG</id>
 		<enumerator>
 		<name>FAST_BACKGROUND_SCRUB</name>
@@ -969,6 +2685,25 @@
 		<enumerator>
 		<name>AVP_ENABLE</name>
 		<value>0x00000002</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MNFG_FLAGS</id>
+		<enumerator>
+		<name>MNFG_NO_FLAG</name>
+		<value>0x0000000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>MNFG_ENABLE_STANDARD_PATTERN_TEST</name>
+		<value>0x0000000000000200</value>
+		</enumerator>
+		<enumerator>
+		<name>MNFG_THRESHOLDS</name>
+		<value>0x0000000000000001</value>
+		</enumerator>
+		<enumerator>
+		<name>MNFG_DISABLE_DRAM_REPAIRS</name>
+		<value>0x0000000000000080</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1158,6 +2893,17 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>MRW_HW_MIRRORING_ENABLE</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>MRW_TYPE</id>
 		<enumerator>
 		<name>IOMUX</name>
@@ -1249,41 +2995,211 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
-	<id>MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
+	<id>MSS_INTERLEAVE_GRANULARITY</id>
 		<enumerator>
-		<name>STR</name>
-		<value>2</value>
+		<name>128_B</name>
+		<value>0x00</value>
 		</enumerator>
 		<enumerator>
-		<name>POWER_DOWN</name>
+		<name>32_KB</name>
+		<value>0x08</value>
+		</enumerator>
+		<enumerator>
+		<name>1_KB</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>8_KB</name>
+		<value>0x06</value>
+		</enumerator>
+		<enumerator>
+		<name>512_B</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>4_KB</name>
+		<value>0x05</value>
+		</enumerator>
+		<enumerator>
+		<name>2_KB</name>
+		<value>0x04</value>
+		</enumerator>
+		<enumerator>
+		<name>16_KB</name>
+		<value>0x07</value>
+		</enumerator>
+		<enumerator>
+		<name>256_B</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_AVDD_OFFSET_DISABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
 		<value>1</value>
 		</enumerator>
 		<enumerator>
-		<name>PD_AND_STR</name>
-		<value>3</value>
+		<name>ENABLE</name>
+		<value>0</value>
 		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_CLEANER_ENABLE</id>
 		<enumerator>
 		<name>OFF</name>
 		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_DRAM_2N_MODE</id>
+		<enumerator>
+		<name>AUTO</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>FORCE_TO_2N_MODE</name>
+		<value>2</value>
+		</enumerator>
+		<enumerator>
+		<name>FORCE_TO_1N_MODE</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_DRAM_WRITE_CRC</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_FINE_REFRESH_MODE</id>
+		<enumerator>
+		<name>FIXED_2X</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>FLY_4X</name>
+		<value>6</value>
+		</enumerator>
+		<enumerator>
+		<name>NORMAL</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>FLY_2X</name>
+		<value>5</value>
+		</enumerator>
+		<enumerator>
+		<name>FIXED_4X</name>
+		<value>2</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
+		<enumerator>
+		<name>POWER_DOWN</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>PD_AND_STR</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>PD_AND_STR_CLK_STOP</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
 	<id>MSS_MRW_POWER_CONTROL_REQUESTED</id>
 		<enumerator>
-		<name>STR</name>
-		<value>2</value>
-		</enumerator>
-		<enumerator>
 		<name>POWER_DOWN</name>
-		<value>1</value>
+		<value>0x01</value>
 		</enumerator>
 		<enumerator>
 		<name>PD_AND_STR</name>
-		<value>3</value>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>PD_AND_STR_CLK_STOP</name>
+		<value>0x03</value>
 		</enumerator>
 		<enumerator>
 		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_PREFETCH_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
 		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_REFRESH_RATE_REQUEST</id>
+		<enumerator>
+		<name>SINGLE_10_PERCENT_FASTER</name>
+		<value>2</value>
+		</enumerator>
+		<enumerator>
+		<name>SINGLE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>DOUBLE</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>DOUBLE_10_PERCENT_FASTER</name>
+		<value>3</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_RESET_DELAY_BEFORE_CAL</id>
+		<enumerator>
+		<name>NO</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>YES</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_SUPPORTED_FREQ</id>
+		<enumerator>
+		<name>MT1866</name>
+		<value>1866</value>
+		</enumerator>
+		<enumerator>
+		<name>MT2400</name>
+		<value>2400</value>
+		</enumerator>
+		<enumerator>
+		<name>MT2666</name>
+		<value>2666</value>
+		</enumerator>
+		<enumerator>
+		<name>MT2133</name>
+		<value>2133</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1295,6 +3211,72 @@
 		<enumerator>
 		<name>ENABLE</name>
 		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_TEMP_REFRESH_RANGE</id>
+		<enumerator>
+		<name>EXTEND</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>NORMAL</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_VCS_OFFSET_DISABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_VDDR_OFFSET_DISABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_VDD_OFFSET_DISABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MSS_MRW_VPP_OFFSET_DISABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1345,6 +3327,29 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>NAME</id>
+		<enumerator>
+		<name>CUMULUS</name>
+		<value>0x6</value>
+		</enumerator>
+		<enumerator>
+		<name>AXONE</name>
+		<value>0x7</value>
+		</enumerator>
+		<enumerator>
+		<name>CENTAUR</name>
+		<value>0x3</value>
+		</enumerator>
+		<enumerator>
+		<name>NONE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>NIMBUS</name>
+		<value>0x5</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>NPU_MMIO_BAR_SIZE</id>
 		<enumerator>
 		<name>1_MB</name>
@@ -1378,12 +3383,16 @@
 		<value>0x0</value>
 		</enumerator>
 		<enumerator>
-		<name>NVLINK</name>
+		<name>CAPI</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>NV</name>
 		<value>0x2</value>
 		</enumerator>
 		<enumerator>
-		<name>CAPILINK</name>
-		<value>0x1</value>
+		<name>OCAPI</name>
+		<value>0x3</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1484,6 +3493,17 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>PGPE_HCODE_FUNCTION_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>PM_APSS_CHIP_SELECT</id>
 		<enumerator>
 		<name>CS1</name>
@@ -1496,6 +3516,17 @@
 		<enumerator>
 		<name>NONE</name>
 		<value>0xFF</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>POUND_W_STATIC_DATA_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>0x01</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1513,22 +3544,26 @@
 	<id>PROC_EPS_TABLE_TYPE</id>
 		<enumerator>
 		<name>EPS_TYPE_HE</name>
-		<value>2</value>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>EPS_TYPE_HE_F8</name>
+		<value>0x03</value>
 		</enumerator>
 		<enumerator>
 		<name>EPS_TYPE_LE</name>
-		<value>1</value>
+		<value>0x01</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
 	<id>PROC_FABRIC_A_BUS_WIDTH</id>
 		<enumerator>
 		<name>4_BYTE</name>
-		<value>2</value>
+		<value>0x02</value>
 		</enumerator>
 		<enumerator>
 		<name>2_BYTE</name>
-		<value>1</value>
+		<value>0x01</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1543,14 +3578,21 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>PROC_FABRIC_CCSM_MODE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>PROC_FABRIC_PUMP_MODE</id>
 		<enumerator>
-		<name>MODE1</name>
-		<value>1</value>
+		<name>CHIP_IS_NODE</name>
+		<value>0x01</value>
 		</enumerator>
 		<enumerator>
-		<name>MODE2</name>
-		<value>2</value>
+		<name>CHIP_IS_GROUP</name>
+		<value>0x02</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1568,26 +3610,447 @@
 	<id>PROC_FABRIC_X_BUS_WIDTH</id>
 		<enumerator>
 		<name>4_BYTE</name>
-		<value>2</value>
+		<value>0x02</value>
 		</enumerator>
 		<enumerator>
 		<name>2_BYTE</name>
-		<value>1</value>
+		<value>0x01</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
-	<id>PROC_MASTER_TYPE</id>
+	<id>PROC_FSP_BAR_ENABLE</id>
 		<enumerator>
-		<name>ACTING_MASTER</name>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_FSP_BAR_SIZE</id>
+		<enumerator>
+		<name>16_MB</name>
+		<value>0xFFFFFC0000FFFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>64_MB</name>
+		<value>0xFFFFFC0003FFFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>512_MB</name>
+		<value>0xFFFFFC001FFFFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>128_MB</name>
+		<value>0xFFFFFC0007FFFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>8_MB</name>
+		<value>0xFFFFFC00007FFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>2_GB</name>
+		<value>0xFFFFFC007FFFFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>32_MB</name>
+		<value>0xFFFFFC0001FFFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>1_MB</name>
+		<value>0xFFFFFC00000FFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>256_MB</name>
+		<value>0xFFFFFC000FFFFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>4_MB</name>
+		<value>0xFFFFFC00003FFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>2_MB</name>
+		<value>0xFFFFFC00001FFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>1_GB</name>
+		<value>0xFFFFFC003FFFFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>4_GB</name>
+		<value>0xFFFFFC00FFFFFFFF</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_FSP_MMIO_MASK_SIZE</id>
+		<enumerator>
+		<name>2_GB</name>
+		<value>0x0070000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>512_MB</name>
+		<value>0x0010000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>256_MB</name>
+		<value>0x0000000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>1_GB</name>
+		<value>0x0030000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>4_GB</name>
+		<value>0x00F0000000000000</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_INT_CQ_IC_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_INT_CQ_IC_BAR_PAGE_SIZE</id>
+		<enumerator>
+		<name>4K</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>64K</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_INT_CQ_PC_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_INT_CQ_TM1_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_INT_CQ_TM1_BAR_PAGE_SIZE</id>
+		<enumerator>
+		<name>4K</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>64K</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_INT_CQ_VC_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_NPU_MMIO_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_NPU_PHY0_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_NPU_PHY1_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_NX_RNG_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_NX_RNG_FAILED_INT_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_PBIEX_ASYNC_SEL</id>
+		<enumerator>
+		<name>SEL0</name>
 		<value>0</value>
 		</enumerator>
 		<enumerator>
-		<name>MASTER_CANDIDATE</name>
+		<name>SEL1</name>
 		<value>1</value>
 		</enumerator>
 		<enumerator>
-		<name>NOT_MASTER</name>
+		<name>SEL2</name>
 		<value>2</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_PCIE_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_PCIE_BAR_SIZE</id>
+		<enumerator>
+		<name>16_PB</name>
+		<value>0xC000000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>4_TB</name>
+		<value>0xFFFC000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>8_PB</name>
+		<value>0xE000000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>2_TB</name>
+		<value>0xFFFE000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>4_PB</name>
+		<value>0xF000000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>16_TB</name>
+		<value>0xFFF0000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>2_PB</name>
+		<value>0xF800000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>512_TB</name>
+		<value>0xFE00000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>256_TB</name>
+		<value>0xFF00000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>128_TB</name>
+		<value>0xFF80000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>8_TB</name>
+		<value>0xFFF8000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>256_GB</name>
+		<value>0xFFFFC00000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>2_GB</name>
+		<value>0xFFFFFF8000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>32_MB</name>
+		<value>0xFFFFFFFE00000000</value>
+		</enumerator>
+		<enumerator>
+		<name>256_KB</name>
+		<value>0xFFFFFFFFFC000000</value>
+		</enumerator>
+		<enumerator>
+		<name>256_MB</name>
+		<value>0xFFFFFFF000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>1_PB</name>
+		<value>0xFC00000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>8_GB</name>
+		<value>0xFFFFFE0000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>4_MB</name>
+		<value>0xFFFFFFFFC0000000</value>
+		</enumerator>
+		<enumerator>
+		<name>2_MB</name>
+		<value>0xFFFFFFFFE0000000</value>
+		</enumerator>
+		<enumerator>
+		<name>128_GB</name>
+		<value>0xFFFFE00000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>512_KB</name>
+		<value>0xFFFFFFFFF8000000</value>
+		</enumerator>
+		<enumerator>
+		<name>64_TB</name>
+		<value>0xFFC0000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>32_GB</name>
+		<value>0xFFFFF80000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>512_GB</name>
+		<value>0xFFFF800000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>4_GB</name>
+		<value>0xFFFFFF0000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>16_MB</name>
+		<value>0xFFFFFFFF00000000</value>
+		</enumerator>
+		<enumerator>
+		<name>64_MB</name>
+		<value>0xFFFFFFFC00000000</value>
+		</enumerator>
+		<enumerator>
+		<name>512_MB</name>
+		<value>0xFFFFFFE000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>128_MB</name>
+		<value>0xFFFFFFF800000000</value>
+		</enumerator>
+		<enumerator>
+		<name>8_MB</name>
+		<value>0xFFFFFFFF80000000</value>
+		</enumerator>
+		<enumerator>
+		<name>128_KB</name>
+		<value>0xFFFFFFFFFE000000</value>
+		</enumerator>
+		<enumerator>
+		<name>32_TB</name>
+		<value>0xFFE0000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>64_KB</name>
+		<value>0xFFFFFFFFFF000000</value>
+		</enumerator>
+		<enumerator>
+		<name>1_TB</name>
+		<value>0xFFFF000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>64_GB</name>
+		<value>0xFFFFF00000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>32_PB</name>
+		<value>0x8000000000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>1_MB</name>
+		<value>0xFFFFFFFFF0000000</value>
+		</enumerator>
+		<enumerator>
+		<name>16_GB</name>
+		<value>0xFFFFFC0000000000</value>
+		</enumerator>
+		<enumerator>
+		<name>16_KB</name>
+		<value>0xFFFFFFFFFFFFFFFF</value>
+		</enumerator>
+		<enumerator>
+		<name>1_GB</name>
+		<value>0xFFFFFFC000000000</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_PSI_BRIDGE_BAR_ENABLE</id>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0x0</value>
+		</enumerator>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>0x1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_SBE_MASTER_CHIP</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>PROC_SELECT_BOOT_MASTER</id>
+		<enumerator>
+		<name>SECONDARY</name>
+		<value>2</value>
+		</enumerator>
+		<enumerator>
+		<name>PRIMARY</name>
+		<value>1</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1694,6 +4157,32 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>REQUIRED_SYNCH_MODE</id>
+		<enumerator>
+		<name>UNDETERMINED</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>NEVER</name>
+		<value>2</value>
+		</enumerator>
+		<enumerator>
+		<name>ALWAYS</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>RISK_LEVEL</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>ROLE</id>
 		<enumerator>
 		<name>BACKUP</name>
@@ -1721,6 +4210,39 @@
 		<enumerator>
 		<name>FRU</name>
 		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SBE_FFDC_ENABLE</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SBE_INTERNAL_FFDC_ENABLE</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SBE_RUNTIME_MODE</id>
+		<enumerator>
+		<name>TRUE</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>FALSE</name>
+		<value>0x0</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1782,12 +4304,20 @@
 		<value>0x0103</value>
 		</enumerator>
 		<enumerator>
+		<name>GPU_STATE</name>
+		<value>0x17D8</value>
+		</enumerator>
+		<enumerator>
 		<name>OCC_ACTIVE</name>
 		<value>0x07D2</value>
 		</enumerator>
 		<enumerator>
 		<name>BACKPLANE_FAULT</name>
 		<value>0xC707</value>
+		</enumerator>
+		<enumerator>
+		<name>GPU_MEM_TEMP</name>
+		<value>0x01D9</value>
 		</enumerator>
 		<enumerator>
 		<name>OS_BOOT</name>
@@ -1818,12 +4348,16 @@
 		<value>0xC7D6</value>
 		</enumerator>
 		<enumerator>
+		<name>GPU_TEMP</name>
+		<value>0x01D8</value>
+		</enumerator>
+		<enumerator>
 		<name>HOST_STATUS</name>
 		<value>0x2223</value>
 		</enumerator>
 		<enumerator>
 		<name>TPM_REQUIRED</name>
-		<value>0xFFFF</value>
+		<value>0xCC03</value>
 		</enumerator>
 		<enumerator>
 		<name>PROC_STATE</name>
@@ -1881,6 +4415,10 @@
 		<value>0x22</value>
 		</enumerator>
 		<enumerator>
+		<name>ADDIN_CARD</name>
+		<value>0x17</value>
+		</enumerator>
+		<enumerator>
 		<name>FREQ</name>
 		<value>0xC1</value>
 		</enumerator>
@@ -1916,6 +4454,50 @@
 		</enumerator>
 		<enumerator>
 		<name>YES</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>STOP11_DISABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>STOP4_DISABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>STOP5_DISABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>STOP8_DISABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
 		<value>1</value>
 		</enumerator>
 </enumerationType>
@@ -1957,11 +4539,67 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
-	<id>SYSTEM_WOF_DISABLE</id>
+	<id>SYSTEM_CORE_PERIODIC_QUIESCE_DISABLE</id>
 		<enumerator>
-		<name>OFF_SKIP_DD</name>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SYSTEM_IPL_PHASE</id>
+		<enumerator>
+		<name>NONHB_IPL</name>
+		<value>0x10</value>
+		</enumerator>
+		<enumerator>
+		<name>HB_RUNTIME</name>
+		<value>0x2</value>
+		</enumerator>
+		<enumerator>
+		<name>CACHE_CONTAINED</name>
+		<value>0x4</value>
+		</enumerator>
+		<enumerator>
+		<name>HB_IPL</name>
+		<value>0x1</value>
+		</enumerator>
+		<enumerator>
+		<name>CHIP_CONTAINED</name>
+		<value>0x8</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SYSTEM_IVRM_DISABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SYSTEM_PSTATES_MODE</id>
+		<enumerator>
+		<name>AUTO</name>
 		<value>0x02</value>
 		</enumerator>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>0x00</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SYSTEM_RESCLK_DISABLE</id>
 		<enumerator>
 		<name>OFF</name>
 		<value>0x00</value>
@@ -1969,6 +4607,36 @@
 		<enumerator>
 		<name>ON</name>
 		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SYSTEM_RING_DBG_MODE</id>
+		<enumerator>
+		<name>SCAN_RING_TRACE_DEBUG</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>SCAN_RING_DEEP_DEBUG</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>SCAN_RING_NO_DEBUG</name>
+		<value>0x00</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SYSTEM_WOF_DISABLE</id>
+		<enumerator>
+		<name>OFF_SKIP_DD</name>
+		<value>2</value>
+		</enumerator>
+		<enumerator>
+		<name>OFF</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>1</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1991,10 +4659,25 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>SYS_VFRT_STATIC_DATA_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>TYPE</id>
 		<enumerator>
 		<name>CORE</name>
 		<value>7</value>
+		</enumerator>
+		<enumerator>
+		<name>MFREFCLK</name>
+		<value>70</value>
 		</enumerator>
 		<enumerator>
 		<name>PS</name>
@@ -2082,7 +4765,7 @@
 		</enumerator>
 		<enumerator>
 		<name>LAST_IN_RANGE</name>
-		<value>70</value>
+		<value>71</value>
 		</enumerator>
 		<enumerator>
 		<name>PCI</name>
@@ -2115,10 +4798,6 @@
 		<enumerator>
 		<name>REFCLKENDPT</name>
 		<value>28</value>
-		</enumerator>
-		<enumerator>
-		<name>NV</name>
-		<value>41</value>
 		</enumerator>
 		<enumerator>
 		<name>NX</name>
@@ -2274,6 +4953,244 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>VDM_DROOP_EXTREME_OVERRIDE</id>
+		<enumerator>
+		<name>8mV</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>56mV</name>
+		<value>0x07</value>
+		</enumerator>
+		<enumerator>
+		<name>88mV</name>
+		<value>0x0B</value>
+		</enumerator>
+		<enumerator>
+		<name>48mV</name>
+		<value>0x06</value>
+		</enumerator>
+		<enumerator>
+		<name>92mV</name>
+		<value>0x0C</value>
+		</enumerator>
+		<enumerator>
+		<name>16mV</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>80mV</name>
+		<value>0x0A</value>
+		</enumerator>
+		<enumerator>
+		<name>24mV</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>96mV</name>
+		<value>0x0D</value>
+		</enumerator>
+		<enumerator>
+		<name>40mV</name>
+		<value>0x05</value>
+		</enumerator>
+		<enumerator>
+		<name>72mV</name>
+		<value>0x09</value>
+		</enumerator>
+		<enumerator>
+		<name>64mV</name>
+		<value>0x08</value>
+		</enumerator>
+		<enumerator>
+		<name>32mV</name>
+		<value>0x04</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>VDM_DROOP_LARGE_OVERRIDE</id>
+		<enumerator>
+		<name>8mV</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>56mV</name>
+		<value>0x07</value>
+		</enumerator>
+		<enumerator>
+		<name>88mV</name>
+		<value>0x0B</value>
+		</enumerator>
+		<enumerator>
+		<name>48mV</name>
+		<value>0x06</value>
+		</enumerator>
+		<enumerator>
+		<name>92mV</name>
+		<value>0x0C</value>
+		</enumerator>
+		<enumerator>
+		<name>16mV</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>80mV</name>
+		<value>0x0A</value>
+		</enumerator>
+		<enumerator>
+		<name>24mV</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>96mV</name>
+		<value>0x0D</value>
+		</enumerator>
+		<enumerator>
+		<name>40mV</name>
+		<value>0x05</value>
+		</enumerator>
+		<enumerator>
+		<name>72mV</name>
+		<value>0x09</value>
+		</enumerator>
+		<enumerator>
+		<name>64mV</name>
+		<value>0x08</value>
+		</enumerator>
+		<enumerator>
+		<name>32mV</name>
+		<value>0x04</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>VDM_DROOP_SMALL_OVERRIDE</id>
+		<enumerator>
+		<name>8mV</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>56mV</name>
+		<value>0x07</value>
+		</enumerator>
+		<enumerator>
+		<name>88mV</name>
+		<value>0x0B</value>
+		</enumerator>
+		<enumerator>
+		<name>48mV</name>
+		<value>0x06</value>
+		</enumerator>
+		<enumerator>
+		<name>92mV</name>
+		<value>0x0C</value>
+		</enumerator>
+		<enumerator>
+		<name>16mV</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>80mV</name>
+		<value>0x0A</value>
+		</enumerator>
+		<enumerator>
+		<name>24mV</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>96mV</name>
+		<value>0x0D</value>
+		</enumerator>
+		<enumerator>
+		<name>40mV</name>
+		<value>0x05</value>
+		</enumerator>
+		<enumerator>
+		<name>72mV</name>
+		<value>0x09</value>
+		</enumerator>
+		<enumerator>
+		<name>64mV</name>
+		<value>0x08</value>
+		</enumerator>
+		<enumerator>
+		<name>32mV</name>
+		<value>0x04</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>VDM_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>VDM_EXTREME_THOTTLE_ENABLE</id>
+		<enumerator>
+		<name>OFF</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>ON</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>VDM_OVERVOLT_OVERRIDE</id>
+		<enumerator>
+		<name>8mV</name>
+		<value>0x01</value>
+		</enumerator>
+		<enumerator>
+		<name>56mV</name>
+		<value>0x07</value>
+		</enumerator>
+		<enumerator>
+		<name>FORCE</name>
+		<value>0x00</value>
+		</enumerator>
+		<enumerator>
+		<name>48mV</name>
+		<value>0x06</value>
+		</enumerator>
+		<enumerator>
+		<name>16mV</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>24mV</name>
+		<value>0x03</value>
+		</enumerator>
+		<enumerator>
+		<name>40mV</name>
+		<value>0x05</value>
+		</enumerator>
+		<enumerator>
+		<name>64mV</name>
+		<value>0x08</value>
+		</enumerator>
+		<enumerator>
+		<name>32mV</name>
+		<value>0x04</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>VIEW_FRONT</id>
 		<enumerator>
 		<name>NO</name>
@@ -2384,22 +5301,22 @@
 	<id>WOF_ENABLE_FRATIO</id>
 		<enumerator>
 		<name>FIXED</name>
-		<value>0x00</value>
+		<value>0</value>
 		</enumerator>
 		<enumerator>
 		<name>STEPPED</name>
-		<value>0x01</value>
+		<value>1</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
 	<id>WOF_ENABLE_VRATIO</id>
 		<enumerator>
 		<name>FIXED</name>
-		<value>0x00</value>
+		<value>0</value>
 		</enumerator>
 		<enumerator>
 		<name>STEPPED</name>
-		<value>0x01</value>
+		<value>1</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -2417,11 +5334,11 @@
 	<id>WOF_VRATIO_SELECT</id>
 		<enumerator>
 		<name>ACTIVE_CORES</name>
-		<value>0x00</value>
+		<value>0</value>
 		</enumerator>
 		<enumerator>
 		<name>FULL</name>
-		<value>0x01</value>
+		<value>1</value>
 		</enumerator>
 </enumerationType>
 </enumerationTypes>
@@ -13066,10 +15983,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default>affinity:sys-0</default>
-	</attribute>
-	<attribute>
 		<id>ALL_MCS_IN_INTERLEAVING_GROUP</id>
 		<default>0x00</default>
 	</attribute>
@@ -13090,7 +16003,15 @@
 		<default>2000</default>
 	</attribute>
 	<attribute>
+		<id>AUX_FUNC_INVOCATION_TIME_MS</id>
+		<default>0x01</default>
+	</attribute>
+	<attribute>
 		<id>AVERAGE_IPL_TIME</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>AVSBUS_FREQUENCY</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -13106,12 +16027,112 @@
 		<default>26</default>
 	</attribute>
 	<attribute>
+		<id>BOOT_FLAGS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>BOOT_FREQ_MHZ</id>
+		<default>2400</default>
+	</attribute>
+	<attribute>
 		<id>BRAZOS_RX_FIFO_OVERRIDE</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>CDM_POLICIES</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>CEN_DDR_REFCLOCK_RCVR_TERM</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CEN_DMI_REFCLOCK_RCVR_TERM</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_CDIMM_MASTER_I2C_TEMP_SENSOR_ENABLE</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_CDIMM_SPARE_I2C_TEMP_SENSOR_ENABLE</id>
+		<default>0x01</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT_IDLE</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_MAX_DRAM_DATABUS_UTIL</id>
+		<default>0x000015f9</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_MAX_NUMBER_DIMMS_POSSIBLE_PER_VMEM_REGULATOR</id>
+		<default>0x04</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_MBA_CACHELINE_INTERLEAVE_MODE_CONTROL</id>
+		<default>0x02</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_MEM_THROTTLE_DENOMINATOR</id>
+		<default>0x00000200</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_POWER_CONTROL_REQUESTED</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_CHIP</id>
+		<default>0x00000020</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_MBA</id>
+		<default>0x00000060</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_STRICT_MBA_PLUG_RULE_CHECKING</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_THERMAL_MEMORY_POWER_LIMIT</id>
+		<default>0x00000d2f</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM</id>
+		<default>0x00000f29</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_VMEM_REGULATOR_MEMORY_POWER_LIMIT_PER_DIMM_DDR4</id>
+		<default>0x00000d79</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_VMEM_REGULATOR_POWER_LIMIT_PER_DIMM_ADJ_ENABLE</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MRW_WR_VREF_CHECK_VREF_STEP_SIZE</id>
+		<default>0x08</default>
+	</attribute>
+	<attribute>
+		<id>CEN_MSS_CLEANER_ENABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CEN_MSS_DRAMINIT_RESET_DISABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CEN_MSS_PREFETCH_ENABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CEN_MSS_VOLT_COMPLIANT_DIMMS</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>CHECK_SCRIPT</id>
@@ -13122,6 +16143,10 @@
 		<default>SYS</default>
 	</attribute>
 	<attribute>
+		<id>CP_REFCLOCK_RCVR_TERM</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>DD1_SLOW_PCI_REF_CLOCK</id>
 		<default>0</default>
 	</attribute>
@@ -13130,8 +16155,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>DMI_DFE_OVERRIDE</id>
-		<default>0</default>
+		<id>DISABLE_HBBL_VECTORS</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>DMI_EREPAIR_THRESHOLD_FIELD</id>
@@ -13171,31 +16196,23 @@
 	</attribute>
 	<attribute>
 		<id>EXTERNAL_VRM_STEPSIZE</id>
-		<default></default>
+		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>EXTERNAL_VRM_TRANSITION_RATE_DEC_UV_PER_US</id>
-		<default></default>
+		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>EXTERNAL_VRM_TRANSITION_RATE_INC_UV_PER_US</id>
-		<default></default>
+		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>EXTERNAL_VRM_TRANSITION_STABILIZATION_TIME_NS</id>
-		<default></default>
+		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>EXTERNAL_VRM_TRANSITION_START_NS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
+		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>FIELD_TH_P8EX_L2_COL_REPAIRS</id>
@@ -13254,6 +16271,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>FREQ_X_MHZ</id>
+		<default>2000</default>
+	</attribute>
+	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
 	</attribute>
@@ -13262,7 +16283,7 @@
 		<default>0x0000000100000000</default>
 	</attribute>
 	<attribute>
-		<id>FUSED_CORE_MODE</id>
+		<id>FUSED_CORE_MODE_HB</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -13283,16 +16304,16 @@
 		<default>0x89000000</default>
 	</attribute>
 	<attribute>
-		<id>HUID</id>
-		<default>0x00010000</default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
 		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_REFCLOCK_RCVR_TERM</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>IPMI_SENSORS</id>
@@ -13391,14 +16412,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MAX_MCS_PER_SYSTEM</id>
-		<default>8</default>
-	</attribute>
-	<attribute>
-		<id>MAX_PROC_CHIPS_PER_NODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MAX_SBE_SEEPROM_SIZE</id>
 		<default>0x40000</default>
 	</attribute>
@@ -13409,6 +16422,10 @@
 	<attribute>
 		<id>MIRROR_BASE_ADDRESS</id>
 		<default>0x0000800000000000</default>
+	</attribute>
+	<attribute>
+		<id>MISC_SYSTEM_COMPONENTS_MAX_POWER_WATTS</id>
+		<default>430</default>
 	</attribute>
 	<attribute>
 		<id>MNFG_ABUS_MIN_EYE_HEIGHT</id>
@@ -13499,14 +16516,6 @@
 		<default>POWER9</default>
 	</attribute>
 	<attribute>
-		<id>MRW_CDIMM_MASTER_I2C_TEMP_SENSOR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRW_CDIMM_SPARE_I2C_TEMP_SENSOR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MRW_DDR3_VDDR_MAX_LIMIT</id>
 		<default>0</default>
 	</attribute>
@@ -13521,10 +16530,6 @@
 	<attribute>
 		<id>MRW_DDR4_VDDR_MAX_LIMIT_POST_DRAM_INIT</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>MRW_DRAMINIT_RESET_DISABLE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>MRW_HW_MIRRORING_ENABLE</id>
@@ -13555,14 +16560,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRW_SAFEMODE_MEM_THROTTLE_NUMERATOR_PER_MBA</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRW_STRICT_MBA_PLUG_RULE_CHECKING</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -13579,20 +16576,12 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>MSS_CLEANER_ENABLE</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
-		<id>MSS_DRAMINIT_RESET_DISABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MSS_INTERLEAVE_ENABLE</id>
 		<default>0xAF</default>
 	</attribute>
 	<attribute>
 		<id>MSS_INTERLEAVE_GRANULARITY</id>
-		<default></default>
+		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MBA_ADDR_INTERLEAVE_BIT</id>
@@ -13608,7 +16597,7 @@
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_CLEANER_ENABLE</id>
-		<default></default>
+		<default>OFF</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_DIMM_POWER_CURVE_PERCENT_UPLIFT</id>
@@ -13619,8 +16608,16 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>MSS_MRW_DRAM_2N_MODE</id>
+		<default>AUTO</default>
+	</attribute>
+	<attribute>
+		<id>MSS_MRW_DRAM_WRITE_CRC</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
 		<id>MSS_MRW_FINE_REFRESH_MODE</id>
-		<default></default>
+		<default>NORMAL</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_IDLE_POWER_CONTROL_REQUESTED</id>
@@ -13635,16 +16632,20 @@
 		<default>8</default>
 	</attribute>
 	<attribute>
+		<id>MSS_MRW_MCS_PREFETCH_RETRY_THRESHOLD</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>MSS_MRW_MEM_M_DRAM_CLOCKS</id>
 		<default>0x00000200</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_PERIODIC_MEMCAL_MODE_OPTIONS</id>
-		<default></default>
+		<default>0xD90C</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_PERIODIC_ZQCAL_MODE_OPTIONS</id>
-		<default></default>
+		<default>0x8000</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_POWER_CONTROL_REQUESTED</id>
@@ -13671,12 +16672,12 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
-		<default></default>
+		<id>MSS_MRW_RESET_DELAY_BEFORE_CAL</id>
+		<default>YES</default>
 	</attribute>
 	<attribute>
-		<id>MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_SLOT</id>
-		<default></default>
+		<id>MSS_MRW_SAFEMODE_MEM_THROTTLED_N_COMMANDS_PER_PORT</id>
+		<default>32</default>
 	</attribute>
 	<attribute>
 		<id>MSS_MRW_SUPPORTED_FREQ</id>
@@ -13713,10 +16714,6 @@
 	<attribute>
 		<id>MSS_MRW_VPP_OFFSET_DISABLE</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>MSS_PREFETCH_ENABLE</id>
-		<default>1</default>
 	</attribute>
 	<attribute>
 		<id>MSS_VCS_PROGRAM</id>
@@ -13810,22 +16807,6 @@
 		<default>ibm,witherspoon</default>
 	</attribute>
 	<attribute>
-		<id>OPEN_POWER_GPU_ERROR_TEMP_DEG_C</id>
-		<default>83</default>
-	</attribute>
-	<attribute>
-		<id>OPEN_POWER_GPU_MEM_READ_TIMEOUT_SEC</id>
-		<default>30</default>
-	</attribute>
-	<attribute>
-		<id>OPEN_POWER_GPU_MEM_ERROR_TEMP_DEG_C</id>
-		<default>85</default>
-	</attribute>
-	<attribute>
-		<id>OPEN_POWER_GPU_READ_TIMEOUT_SEC</id>
-		<default>30</default>
-	</attribute>
-	<attribute>
 		<id>OPEN_POWER_DIMM_ERROR_TEMP_DEG_C</id>
 		<default>74</default>
 	</attribute>
@@ -13836,6 +16817,22 @@
 	<attribute>
 		<id>OPEN_POWER_DIMM_THROTTLE_TEMP_DEG_C</id>
 		<default>74</default>
+	</attribute>
+	<attribute>
+		<id>OPEN_POWER_GPU_ERROR_TEMP_DEG_C</id>
+		<default>83</default>
+	</attribute>
+	<attribute>
+		<id>OPEN_POWER_GPU_MEM_ERROR_TEMP_DEG_C</id>
+		<default>85</default>
+	</attribute>
+	<attribute>
+		<id>OPEN_POWER_GPU_MEM_READ_TIMEOUT_SEC</id>
+		<default>30</default>
+	</attribute>
+	<attribute>
+		<id>OPEN_POWER_GPU_READ_TIMEOUT_SEC</id>
+		<default>30</default>
 	</attribute>
 	<attribute>
 		<id>OPEN_POWER_MEMCTRL_ERROR_TEMP_DEG_C</id>
@@ -13874,16 +16871,8 @@
 		<default>2500</default>
 	</attribute>
 	<attribute>
-        	<id>OPEN_POWER_N_PLUS_ONE_HPC_BULK_POWER_LIMIT_WATTS</id>
-        	<default>3050</default>
-    	</attribute>
-	<attribute>
 		<id>OPEN_POWER_N_PLUS_ONE_MAX_MEM_POWER_WATTS</id>
 		<default>238</default>
-	</attribute>
-	<attribute>
-		<id>MISC_SYSTEM_COMPONENTS_MAX_POWER_WATTS</id>
-		<default>430</default>
 	</attribute>
 	<attribute>
 		<id>OPEN_POWER_PM_MODE</id>
@@ -13930,14 +16919,6 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>OPT_MEMMAP_GROUP_POLICY</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>PAYLOAD_IN_MIRROR_MEM</id>
 		<default>0</default>
 	</attribute>
@@ -13962,20 +16943,12 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>PFET_POWERDOWN_DELAY_NS</id>
-		<default>0</default>
+		<id>PERF_24x7_INVOCATION_TIME_MS</id>
+		<default>0x1</default>
 	</attribute>
 	<attribute>
-		<id>PFET_POWERUP_DELAY_NS</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PFET_VCS_VOFF_SEL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PFET_VDD_VOFF_SEL</id>
-		<default>0</default>
+		<id>PGPE_HCODE_FUNCTION_ENABLE</id>
+		<default>0x1</default>
 	</attribute>
 	<attribute>
 		<id>PHYP_SYSTEM_TYPE</id>
@@ -13984,6 +16957,18 @@
 	<attribute>
 		<id>PHYS_PATH</id>
 		<default>physical:sys-0</default>
+	</attribute>
+	<attribute>
+		<id>PIBMEM_REPAIR0</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PIBMEM_REPAIR1</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PIBMEM_REPAIR2</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>PLCK_IPL_ATTR_OVERRIDES_EXIST</id>
@@ -14083,6 +17068,38 @@
 		<default>0x0010000000000000</default>
 	</attribute>
 	<attribute>
+		<id>PROC_INT_CQ_IC_BAR_BASE_ADDR_OFFSET</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_INT_CQ_IC_BAR_PAGE_SIZE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_INT_CQ_PC_BAR_BASE_ADDR_OFFSET</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_INT_CQ_PC_BAR_BASE_ADDR_OFFSET_MASK</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_INT_CQ_TM1_BAR_BASE_ADDR_OFFSET</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_INT_CQ_TM1_BAR_PAGE_SIZE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_INT_CQ_VC_BAR_BASE_ADDR_OFFSET</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_INT_CQ_VC_BAR_BASE_ADDR_OFFSET_MASK</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>PROC_LPC_BAR_BASE_ADDR_OFFSET</id>
 		<default></default>
 	</attribute>
@@ -14131,6 +17148,14 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>PULSE_MODE_ENABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PULSE_MODE_VALUE</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>RCD_PARITY_RECONFIG_LOOPS_ALLOWED</id>
 		<default>1</default>
 	</attribute>
@@ -14151,6 +17176,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>RISK_LEVEL</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>RUN_MAX_MEM_PATTERNS</id>
 		<default>0</default>
 	</attribute>
@@ -14167,7 +17196,15 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>SECTOR_BUFFER_STRENGTH</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>SECURITY_ENABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SPIPSS_FREQUENCY</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -14183,8 +17220,20 @@
 		</default>
 	</attribute>
 	<attribute>
+		<id>STOP11_DISABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>STOP4_DISABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>STOP5_DISABLE</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>STOP8_DISABLE</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>SUPPORTED_STOP_STATES</id>
@@ -14195,12 +17244,20 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>SYSTEM_CORE_PERIODIC_QUIESCE_DISABLE</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
 		<id>SYSTEM_FAMILY</id>
 		<default>ibm,p9-openbmc</default>
 	</attribute>
 	<attribute>
 		<id>SYSTEM_IPL_PHASE</id>
 		<default>0x1</default>
+	</attribute>
+	<attribute>
+		<id>SYSTEM_IVRM_DISABLE</id>
+		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>SYSTEM_MTM</id>
@@ -14211,7 +17268,19 @@
 		<default>WITHERSPOON</default>
 	</attribute>
 	<attribute>
+		<id>SYSTEM_PSTATES_MODE</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>SYSTEM_RESCLK_DISABLE</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
 		<id>SYSTEM_RESCLK_STEP_DELAY</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SYSTEM_RING_DBG_MODE</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -14223,8 +17292,12 @@
 		<default>OFF</default>
 	</attribute>
 	<attribute>
-		<id>SYS_VFRT_STATIC_DATA_ENABLE</id>
+		<id>SYS_FORCE_ALL_CORES</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>SYS_VFRT_STATIC_DATA_ENABLE</id>
+		<default>0x0</default>
 	</attribute>
 	<attribute>
 		<id>TEST_NEGATIVE_FCN</id>
@@ -14241,6 +17314,54 @@
 	<attribute>
 		<id>TYPE</id>
 		<default>SYS</default>
+	</attribute>
+	<attribute>
+		<id>VDM_DROOP_EXTREME_OVERRIDE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_DROOP_LARGE_OVERRIDE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_DROOP_SMALL_OVERRIDE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_EXTREME_THOTTLE_ENABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_FMAX_OVERRIDE_KHZ</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_FMIN_OVERRIDE_KHZ</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_FREQ_RETURN_L_S_OVERRIDE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_FREQ_RETURN_S_N_OVERRIDE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_LARGE_FREQ_DROP_N_L_OVERRIDE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_OVERVOLT_OVERRIDE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_SMALL_FREQ_DROP_N_S_OVERRIDE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VDM_VID_COMPARE_OVERRIDE_MV</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>WOF_ENABLE_FRATIO</id>
@@ -14292,10 +17413,6 @@
 	<hidden_child_id>tod_clk_sensor</hidden_child_id>
 	<hidden_child_id>apss_fault_sensor</hidden_child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>CDM_DOMAIN</id>
 		<default>NODE</default>
 	</attribute>
@@ -14326,24 +17443,12 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FIELD_CORE_OVERRIDE</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>FRU_ID</id>
 		<default>3</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -14366,10 +17471,6 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>PHYS_PATH</id>
 		<default></default>
 	</attribute>
@@ -14389,10 +17490,6 @@
 	<attribute>
 		<id>TYPE</id>
 		<default>NODE</default>
-	</attribute>
-	<attribute>
-		<id>VPD_REC_NUM</id>
-		<default>0xFFFF</default>
 	</attribute>
 </targetInstance>
 <targetInstance>
@@ -14449,10 +17546,6 @@
 	<child_id>skipper-14</child_id>
 	<child_id>sata-0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>CARD_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -14463,18 +17556,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -14499,10 +17580,6 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -16758,10 +19835,6 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
-		<bus_attribute>
-			<id>ISDIMM_MBVPD_INDEX</id>
-		<default>0</default>
-		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>proc_socket-0/module-0/p9_proc_m/lpc-master => boxconn-6/boxelder-1/bmc-0/chip-bmc-ast2500.pin_G21_espi_lpc_gpioac0ac7/chip-bmc-ast2500.pingroup_lpc/chip-bmc-ast2500.LPC</bus_id>
@@ -18053,10 +21126,6 @@
 	<position>0</position>
 	<child_id>p9_proc_m</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>CARD_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -18067,18 +21136,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -18103,10 +21160,6 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -18283,28 +21336,24 @@
 	<hidden_child_id>cpu_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpu_func_sensor</hidden_child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
+		<id>BACKUP_SEEPROM_SELECT</id>
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
+		<id>BOOT_FREQ_MHZ</id>
+		<default>2400</default>
 	</attribute>
 	<attribute>
 		<id>BOOT_FREQ_MULT</id>
 		<default>150</default>
 	</attribute>
 	<attribute>
-		<id>CDM_DOMAIN</id>
-		<default>FABRIC</default>
+		<id>BRANCH_PIBMEM_ADDR</id>
+		<default></default>
 	</attribute>
 	<attribute>
-		<id>CHIP_HAS_SBE</id>
-		<default>1</default>
+		<id>CDM_DOMAIN</id>
+		<default>FABRIC</default>
 	</attribute>
 	<attribute>
 		<id>CLASS</id>
@@ -18319,8 +21368,32 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>CME_CHTM_TRACE_ENABLE</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>CME_CHTM_TRACE_MEMORY_CONFIG</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CME_INSTRUCTION_TRACE_ENABLE</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>CORE_THROTTLE_ASSERT_COUNT</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CORE_THROTTLE_DEASSERT_COUNT</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>CPU_ATTR</id>
 		<default>0x0000001D</default>
+	</attribute>
+	<attribute>
+		<id>CP_FILTER_BYPASS</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>DATA_CACHE_LINE_SIZE</id>
@@ -18347,8 +21420,24 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
+		<id>DPLL_BYPASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>DUMMY_RW</id>
 		<default>5</default>
+	</attribute>
+	<attribute>
+		<id>DUMP_STOP_INFO_ENABLE_ERRORLOG</id>
+		<default>1</default>
+	</attribute>
+	<attribute>
+		<id>DUMP_STOP_INFO_SUPPRESS_ERROR_TRACE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>EC_GARD</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>EEPROM_SBE_BACKUP_INFO</id>
@@ -18407,11 +21496,7 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>EXTERNAL_VRM_STEPDELAY</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>EXTERNAL_VRM_STEPSIZE</id>
+		<id>EQ_GARD</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -18423,12 +21508,20 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
+		<id>FREQ_BIAS_NOMINAL</id>
+		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
+		<id>FREQ_BIAS_POWERSAVE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FREQ_BIAS_TURBO</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>FREQ_BIAS_ULTRATURBO</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>FREQ_O_MHZ</id>
@@ -18439,31 +21532,11 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FSI_GP_REG_SCOM_ACCESS</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
-	</attribute>
-	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
 		<default>
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>FSP_BAR_SIZE</id>
@@ -18479,6 +21552,10 @@
 	</attribute>
 	<attribute>
 		<id>HDAT_I2C_BUS_FREQ</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HDAT_I2C_DEVICE_LABEL</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -18513,10 +21590,6 @@
             </default>
 	</attribute>
 	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -18535,10 +21608,6 @@
 	<attribute>
 		<id>I2C_BUS_SPEED_ARRAY</id>
 		<default>400,400,0,0,0,0,0,0,0,0,0,0,0,400,400,400,400,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</default>
-	</attribute>
-	<attribute>
-		<id>I2C_SLAVE_ADDRESS</id>
-		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>ICACHE_ASSOC_SETS</id>
@@ -18565,6 +21634,10 @@
 		<default>0xFFFFFFFFFFFFFFFF</default>
 	</attribute>
 	<attribute>
+		<id>IO_FILTER_BYPASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>IPMI_INSTANCE</id>
 		<default>0xFF</default>
 	</attribute>
@@ -18575,6 +21648,10 @@
 	<attribute>
 		<id>ISTEP_MODE</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>IS_SP_MODE</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>L2_CACHE_ASSOC_SETS</id>
@@ -18597,7 +21674,19 @@
 		<default>10240</default>
 	</attribute>
 	<attribute>
-		<id>LPC_BASE_ADDR</id>
+		<id>LEN_OF_SEEPROM_DATA</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MASTER_CORE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MASTER_EX</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MB_BIT_RATE_DIVISOR_PLL</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -18609,12 +21698,12 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>NEST_MEM_X_O_PCI_BYPASS</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>NEST_VCS_ID</id>
@@ -18634,14 +21723,6 @@
 	</attribute>
 	<attribute>
 		<id>NEST_VIO_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>NPU_MMIO_BAR_BASE_ADDR</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>NPU_MMIO_BAR_SIZE</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -18685,10 +21766,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>PBAX_BRDCST_ID_VECTOR</id>
 		<default></default>
 	</attribute>
@@ -18709,6 +21786,10 @@
 		<default>0x0</default>
 	</attribute>
 	<attribute>
+		<id>PFET_OFF_CONTROLS</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>PHB_BASE_ADDRS</id>
 		<default>0</default>
 	</attribute>
@@ -18723,38 +21804,6 @@
 	<attribute>
 		<id>PM_PBAX_NODEID</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>PM_PFET_POWERDOWN_CORE_DELAY0</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PM_PFET_POWERDOWN_CORE_DELAY1</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PM_PFET_POWERDOWN_ECO_DELAY0</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PM_PFET_POWERDOWN_ECO_DELAY1</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PM_PFET_POWERUP_CORE_DELAY0</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PM_PFET_POWERUP_CORE_DELAY1</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PM_PFET_POWERUP_ECO_DELAY0</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PM_PFET_POWERUP_ECO_DELAY1</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>PM_SLEEP_ENTRY</id>
@@ -18793,10 +21842,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>PNOR_I2C_ADDRESS_BYTES</id>
-		<default>4</default>
-	</attribute>
-	<attribute>
 		<id>POSITION</id>
 		<default>0</default>
 	</attribute>
@@ -18814,14 +21859,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>PROC_EFF_FABRIC_CHIP_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PROC_EFF_FABRIC_GROUP_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PROC_FABRIC_SYSTEM_ID</id>
 		<default>0</default>
 	</attribute>
@@ -18834,12 +21871,20 @@
 		<default>0x00000000</default>
 	</attribute>
 	<attribute>
-		<id>PROC_LPC_BAR_BASE_ADDR_OFFSET</id>
+		<id>PROC_INT_CQ_IC_BAR_ENABLE</id>
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>PROC_MASTER_TYPE</id>
-		<default>NOT_MASTER</default>
+		<id>PROC_INT_CQ_PC_BAR_ENABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_INT_CQ_TM1_BAR_ENABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_INT_CQ_VC_BAR_ENABLE</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>PROC_NPU_MMIO_BAR_ENABLE</id>
@@ -18858,23 +21903,27 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_IOP</id>
-		<default>3</default>
+		<id>PROC_NX_RNG_FAILED_INT_ADDR</id>
+		<default></default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_LANES</id>
-		<default>48</default>
+		<id>PROC_NX_RNG_FAILED_INT_ENABLE</id>
+		<default></default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_PEC</id>
-		<default>3</default>
+		<id>PROC_PB_BNDY_DMIPLL_DATA</id>
+		<default></default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_PHB</id>
-		<default>6</default>
+		<id>PROC_PB_BNDY_DMIPLL_FOR_DCCAL_DATA</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>PROC_PCIE_PHB_ACTIVE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_PERV_BNDY_PLL_DATA</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -18906,8 +21955,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>PROC_SECURITY_SETUP_VECTOR</id>
-		<default>0x8000000080000000</default>
+		<id>PROC_SBE_MASTER_CHIP</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>PROC_VRM_VOFFSET_VCS_UV</id>
@@ -18922,10 +21971,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>PSI_HB_ESB_ADDR</id>
-		<default>0,0x00060302031C0000,0x200000000000</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -18938,8 +21983,28 @@
 		<default>FRU</default>
 	</attribute>
 	<attribute>
-		<id>SBE_SEEPROM_I2C_ADDRESS_BYTES</id>
-		<default>2</default>
+		<id>SBE_FFDC_ENABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SBE_INTERNAL_FFDC_ENABLE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SBE_RUNTIME_MODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>SS_FILTER_BYPASS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>START_PIBMEM_ADDR</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>START_SEEPROM_ADDR</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>TDP_RDP_CURRENT_FACTOR</id>
@@ -19006,6 +22071,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>VDM_VID_COMPARE_BIAS_0P5PCT</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>VDN_AVSBUS_BUSNUM</id>
 		<default>1</default>
 	</attribute>
@@ -19014,8 +22083,60 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>VPD_REC_NUM</id>
-		<default>0xFFFF</default>
+		<id>VOLTAGE_EXT_VCS_BIAS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VOLTAGE_EXT_VDD_BIAS_NOMINAL</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VOLTAGE_EXT_VDD_BIAS_POWERSAVE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VOLTAGE_EXT_VDD_BIAS_TURBO</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VOLTAGE_EXT_VDD_BIAS_ULTRATURBO</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VOLTAGE_EXT_VDN_BIAS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VOLTAGE_INT_VDD_BIAS_NOMINAL</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VOLTAGE_INT_VDD_BIAS_POWERSAVE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VOLTAGE_INT_VDD_BIAS_TURBO</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>VOLTAGE_INT_VDD_BIAS_ULTRATURBO</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>WAIT_N0</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>WAIT_N1</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>WAIT_N2</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>WAIT_N3</id>
+		<default></default>
 	</attribute>
 	<attribute>
 		<id>XIVE_HW_RESET</id>
@@ -19030,10 +22151,6 @@
 	<position>-1</position>
 	<child_id>ex0</child_id>
 	<child_id>ex1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -19059,16 +22176,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -19083,24 +22192,20 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PHYS_PATH</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM_OVERRIDE</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>PRIMARY_CAPABILITIES</id>
@@ -19110,10 +22215,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -19133,10 +22234,6 @@
 	<child_id>core0</child_id>
 	<child_id>core1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -19161,16 +22258,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -19185,16 +22274,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -19208,10 +22289,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -19231,10 +22308,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -19260,16 +22333,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -19288,20 +22353,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -19315,10 +22368,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -19492,10 +22541,6 @@
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -19520,16 +22565,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -19548,20 +22585,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -19575,10 +22600,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -19597,10 +22618,6 @@
 	<position>-1</position>
 	<child_id>core2</child_id>
 	<child_id>core3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -19626,16 +22643,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -19650,16 +22659,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -19673,10 +22674,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -19696,10 +22693,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -19725,16 +22718,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -19753,20 +22738,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -19780,10 +22753,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -19803,10 +22772,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -19832,16 +22797,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -19860,20 +22817,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -19887,10 +22832,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -19909,10 +22850,6 @@
 	<position>-1</position>
 	<child_id>ex2</child_id>
 	<child_id>ex3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -19938,16 +22875,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -19962,24 +22891,20 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PHYS_PATH</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM_OVERRIDE</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>PRIMARY_CAPABILITIES</id>
@@ -19989,10 +22914,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20011,10 +22932,6 @@
 	<position>-1</position>
 	<child_id>core4</child_id>
 	<child_id>core5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20040,16 +22957,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -20064,16 +22973,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -20087,10 +22988,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20110,10 +23007,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20139,16 +23032,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -20167,20 +23052,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -20194,10 +23067,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20217,10 +23086,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20246,16 +23111,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -20274,20 +23131,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -20301,10 +23146,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20323,10 +23164,6 @@
 	<position>-1</position>
 	<child_id>core6</child_id>
 	<child_id>core7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20352,16 +23189,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -20376,16 +23205,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -20399,10 +23220,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20422,10 +23239,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20451,16 +23264,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -20479,20 +23284,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -20506,10 +23299,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20529,10 +23318,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20558,16 +23343,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -20586,20 +23363,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -20613,10 +23378,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20635,10 +23396,6 @@
 	<position>-1</position>
 	<child_id>ex4</child_id>
 	<child_id>ex5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20664,16 +23421,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -20688,24 +23437,20 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PHYS_PATH</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM_OVERRIDE</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>PRIMARY_CAPABILITIES</id>
@@ -20715,10 +23460,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20737,10 +23478,6 @@
 	<position>-1</position>
 	<child_id>core8</child_id>
 	<child_id>core9</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20766,16 +23503,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -20790,16 +23519,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -20813,10 +23534,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20836,10 +23553,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20865,16 +23578,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -20893,20 +23598,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -20920,10 +23613,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -20943,10 +23632,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -20972,16 +23657,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21000,20 +23677,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21027,10 +23692,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21049,10 +23710,6 @@
 	<position>-1</position>
 	<child_id>core10</child_id>
 	<child_id>core11</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -21078,16 +23735,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21102,16 +23751,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21125,10 +23766,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21148,10 +23785,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -21177,16 +23810,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21205,20 +23830,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21232,10 +23845,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21255,10 +23864,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -21284,16 +23889,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21312,20 +23909,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21339,10 +23924,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21361,10 +23942,6 @@
 	<position>-1</position>
 	<child_id>ex6</child_id>
 	<child_id>ex7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -21390,16 +23967,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21414,24 +23983,20 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PHYS_PATH</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM_OVERRIDE</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>PRIMARY_CAPABILITIES</id>
@@ -21441,10 +24006,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21463,10 +24024,6 @@
 	<position>-1</position>
 	<child_id>core12</child_id>
 	<child_id>core13</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -21492,16 +24049,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21516,16 +24065,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21539,10 +24080,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21562,10 +24099,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -21591,16 +24124,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21619,20 +24144,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21646,10 +24159,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21669,10 +24178,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -21698,16 +24203,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21726,20 +24223,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21753,10 +24238,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21775,10 +24256,6 @@
 	<position>-1</position>
 	<child_id>core14</child_id>
 	<child_id>core15</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -21804,16 +24281,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21828,16 +24297,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21851,10 +24312,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21874,10 +24331,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -21903,16 +24356,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -21931,20 +24376,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -21958,10 +24391,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -21981,10 +24410,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22010,16 +24435,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22038,20 +24455,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -22065,10 +24470,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -22087,10 +24488,6 @@
 	<position>-1</position>
 	<child_id>ex8</child_id>
 	<child_id>ex9</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22116,16 +24513,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22140,24 +24529,20 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PHYS_PATH</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM_OVERRIDE</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>PRIMARY_CAPABILITIES</id>
@@ -22167,10 +24552,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -22189,10 +24570,6 @@
 	<position>-1</position>
 	<child_id>core16</child_id>
 	<child_id>core17</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22218,16 +24595,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22242,16 +24611,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -22265,10 +24626,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -22288,10 +24645,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22317,16 +24670,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22345,20 +24690,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -22372,10 +24705,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -22395,10 +24724,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22424,16 +24749,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22452,20 +24769,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -22479,10 +24784,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -22501,10 +24802,6 @@
 	<position>-1</position>
 	<child_id>core18</child_id>
 	<child_id>core19</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22530,16 +24827,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22554,16 +24843,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -22577,10 +24858,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -22600,10 +24877,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22629,16 +24902,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22657,20 +24922,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -22684,10 +24937,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -22707,10 +24956,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22736,16 +24981,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22764,20 +25001,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -22791,10 +25016,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -22813,10 +25034,6 @@
 	<position>-1</position>
 	<child_id>ex10</child_id>
 	<child_id>ex11</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22842,16 +25059,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22866,24 +25075,20 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PHYS_PATH</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>POUNDV_BUCKET_NUM_OVERRIDE</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>PRIMARY_CAPABILITIES</id>
@@ -22893,10 +25098,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -22915,10 +25116,6 @@
 	<position>-1</position>
 	<child_id>core20</child_id>
 	<child_id>core21</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -22944,16 +25141,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -22968,16 +25157,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -22991,10 +25172,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23014,10 +25191,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -23043,16 +25216,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -23071,20 +25236,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23098,10 +25251,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23121,10 +25270,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -23150,16 +25295,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -23178,20 +25315,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23205,10 +25330,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23227,10 +25348,6 @@
 	<position>-1</position>
 	<child_id>core22</child_id>
 	<child_id>core23</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -23256,16 +25373,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -23280,16 +25389,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23303,10 +25404,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23326,10 +25423,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -23355,16 +25448,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -23383,20 +25468,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23410,10 +25483,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23433,10 +25502,6 @@
 	<hidden_child_id>cpucore_temp_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_func_sensor</hidden_child_id>
 	<hidden_child_id>cpucore_freq_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -23462,16 +25527,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -23490,20 +25547,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23517,10 +25562,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23538,10 +25579,6 @@
 	<instance_name>occ</instance_name>
 	<position>-1</position>
 	<hidden_child_id>occ_active_sensor</hidden_child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -23563,18 +25600,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -23591,20 +25616,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>OCC_MASTER_CAPABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23618,10 +25631,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23690,10 +25699,6 @@
 	<instance_name>nx</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -23718,18 +25723,6 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -23742,16 +25735,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23765,10 +25750,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23786,10 +25767,6 @@
 	<instance_name>capp0</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -23814,16 +25791,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -23838,20 +25807,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23865,10 +25822,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23886,10 +25839,6 @@
 	<instance_name>capp1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -23914,16 +25863,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -23938,20 +25879,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -23965,10 +25894,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -23985,10 +25910,6 @@
 	<is_root>false</is_root>
 	<instance_name>sbe</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -24010,16 +25931,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -24034,16 +25947,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -24057,10 +25962,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -24078,10 +25979,6 @@
 	<instance_name>pec0</instance_name>
 	<position>-1</position>
 	<child_id>pec0_x16_config</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -24107,16 +26004,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -24131,20 +26020,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEC_PCIE_IOP_REVERSAL</id>
@@ -24163,16 +26040,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>PEC_PCIE_IOP_SWAP_NON_BIFURCATED</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PEC_PCIE_LANE_MASK_BIFURCATED</id>
 		<default>0,0,0,0</default>
-	</attribute>
-	<attribute>
-		<id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
-		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -24190,14 +26059,6 @@
 	<attribute>
 		<id>PROC_PCIE_IOP_CONFIG</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_IOP_SWAP</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_LANE_MASK</id>
-		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PROC_PCIE_PCS_M_CNTL</id>
@@ -24288,10 +26149,6 @@
 		<default>0xFF</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -24307,10 +26164,6 @@
 	<instance_name>pec0_x16_config</instance_name>
 	<position>-1</position>
 	<child_id>phb0_x16</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -24332,18 +26185,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -24360,16 +26201,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>PCI_CONFIGS</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -24383,10 +26216,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -24404,10 +26233,6 @@
 	<instance_name>phb0_x16</instance_name>
 	<position>-1</position>
 	<child_id>phb0_x16_pci</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -24437,20 +26262,8 @@
 		<default>0x34C1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HDDW_ORDER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -24461,52 +26274,12 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MAX_POWER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MGC_LOAD_SOURCE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_CAPABILITES</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -24522,15 +26295,7 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_BAR_BASE_ADDR</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_PCIE_BAR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_BAR_SIZE</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -24552,24 +26317,8 @@
         </default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_LANES</id>
-		<default>48</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SLOT_NAME</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>SUBSYSTEM_DEVICE_ID</id>
@@ -24595,10 +26344,6 @@
 	<instance_name>phb0_x16_pci</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>PCIE</default>
 	</attribute>
@@ -24651,18 +26396,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -24683,16 +26416,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PCIE_LANE_GROUP</id>
@@ -24724,10 +26449,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -24747,10 +26468,6 @@
 	<instance_name>pec1</instance_name>
 	<position>-1</position>
 	<child_id>pec1_x8_x8_config</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -24776,16 +26493,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -24800,20 +26509,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEC_PCIE_IOP_REVERSAL</id>
@@ -24832,16 +26529,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>PEC_PCIE_IOP_SWAP_NON_BIFURCATED</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PEC_PCIE_LANE_MASK_BIFURCATED</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
-		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -24859,14 +26548,6 @@
 	<attribute>
 		<id>PROC_PCIE_IOP_CONFIG</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_IOP_SWAP</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_LANE_MASK</id>
-		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PROC_PCIE_PCS_M_CNTL</id>
@@ -24957,10 +26638,6 @@
 		<default>0xFF</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -24977,10 +26654,6 @@
 	<position>-1</position>
 	<child_id>phb1_x8</child_id>
 	<child_id>phb2_x8</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -25002,18 +26675,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -25030,16 +26691,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>PCI_CONFIGS</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -25053,10 +26706,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -25074,10 +26723,6 @@
 	<instance_name>phb1_x8</instance_name>
 	<position>-1</position>
 	<child_id>phb1_x8_pci</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -25107,20 +26752,8 @@
 		<default>0x34C1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HDDW_ORDER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -25131,52 +26764,12 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MAX_POWER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MGC_LOAD_SOURCE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_CAPABILITES</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -25192,15 +26785,7 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_BAR_BASE_ADDR</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_PCIE_BAR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_BAR_SIZE</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -25222,24 +26807,8 @@
         </default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_LANES</id>
-		<default>48</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SLOT_NAME</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>SUBSYSTEM_DEVICE_ID</id>
@@ -25264,10 +26833,6 @@
 	<is_root>false</is_root>
 	<instance_name>phb1_x8_pci</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>PCIE</default>
@@ -25321,18 +26886,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -25353,16 +26906,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PCIE_LANE_GROUP</id>
@@ -25394,10 +26939,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -25417,10 +26958,6 @@
 	<instance_name>phb2_x8</instance_name>
 	<position>-1</position>
 	<child_id>phb2_x8_pci</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -25450,20 +26987,8 @@
 		<default>0x34C1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HDDW_ORDER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -25474,52 +26999,12 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MAX_POWER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MGC_LOAD_SOURCE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_CAPABILITES</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -25535,15 +27020,7 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_BAR_BASE_ADDR</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_PCIE_BAR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_BAR_SIZE</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -25565,24 +27042,8 @@
         </default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_LANES</id>
-		<default>48</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SLOT_NAME</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>SUBSYSTEM_DEVICE_ID</id>
@@ -25607,10 +27068,6 @@
 	<is_root>false</is_root>
 	<instance_name>phb2_x8_pci</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>PCIE</default>
@@ -25664,18 +27121,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -25696,16 +27141,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PCIE_LANE_GROUP</id>
@@ -25737,10 +27174,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -25762,10 +27195,6 @@
 	<child_id>pec2_x16_config</child_id>
 	<child_id>pec2_x8_x8_config</child_id>
 	<child_id>pec2_x8_x4_x4_config</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -25791,16 +27220,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -25815,20 +27236,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEC_PCIE_IOP_REVERSAL</id>
@@ -25847,16 +27256,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>PEC_PCIE_IOP_SWAP_NON_BIFURCATED</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>PEC_PCIE_LANE_MASK_BIFURCATED</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PEC_PCIE_LANE_MASK_NON_BIFURCATED</id>
-		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -25874,14 +27275,6 @@
 	<attribute>
 		<id>PROC_PCIE_IOP_CONFIG</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_IOP_SWAP</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_LANE_MASK</id>
-		<default>0x0000,0x0000,0x0000,0x0000</default>
 	</attribute>
 	<attribute>
 		<id>PROC_PCIE_PCS_M_CNTL</id>
@@ -25972,10 +27365,6 @@
 		<default>0xFF</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -25991,10 +27380,6 @@
 	<instance_name>pec2_x16_config</instance_name>
 	<position>-1</position>
 	<child_id>phb3_x16</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -26016,18 +27401,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -26044,16 +27417,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>PCI_CONFIGS</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -26067,10 +27432,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -26088,10 +27449,6 @@
 	<instance_name>phb3_x16</instance_name>
 	<position>-1</position>
 	<child_id>phb3_x16_pci</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -26121,20 +27478,8 @@
 		<default>0x34C1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HDDW_ORDER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -26145,52 +27490,12 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MAX_POWER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MGC_LOAD_SOURCE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_CAPABILITES</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -26206,15 +27511,7 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_BAR_BASE_ADDR</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_PCIE_BAR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_BAR_SIZE</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -26236,24 +27533,8 @@
         </default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_LANES</id>
-		<default>48</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SLOT_NAME</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>SUBSYSTEM_DEVICE_ID</id>
@@ -26278,10 +27559,6 @@
 	<is_root>false</is_root>
 	<instance_name>phb3_x16_pci</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>PCIE</default>
@@ -26335,18 +27612,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -26367,16 +27632,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PCIE_LANE_GROUP</id>
@@ -26408,10 +27665,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -26433,10 +27686,6 @@
 	<child_id>phb3_x8</child_id>
 	<child_id>phb4_x8</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -26457,18 +27706,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -26485,16 +27722,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>PCI_CONFIGS</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -26508,10 +27737,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -26529,10 +27754,6 @@
 	<instance_name>phb3_x8</instance_name>
 	<position>-1</position>
 	<child_id>phb3_x8_pci</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -26562,20 +27783,8 @@
 		<default>0x34C1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HDDW_ORDER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -26586,52 +27795,12 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MAX_POWER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MGC_LOAD_SOURCE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_CAPABILITES</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -26647,15 +27816,7 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_BAR_BASE_ADDR</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_PCIE_BAR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_BAR_SIZE</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -26677,24 +27838,8 @@
         </default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_LANES</id>
-		<default>48</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SLOT_NAME</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>SUBSYSTEM_DEVICE_ID</id>
@@ -26719,10 +27864,6 @@
 	<is_root>false</is_root>
 	<instance_name>phb3_x8_pci</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>PCIE</default>
@@ -26776,18 +27917,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -26808,16 +27937,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PCIE_LANE_GROUP</id>
@@ -26849,10 +27970,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -26872,10 +27989,6 @@
 	<instance_name>phb4_x8</instance_name>
 	<position>-1</position>
 	<child_id>phb4_x8_pci</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -26905,20 +28018,8 @@
 		<default>0x34C1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HDDW_ORDER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -26929,52 +28030,12 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MAX_POWER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MGC_LOAD_SOURCE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_CAPABILITES</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -26990,15 +28051,7 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_BAR_BASE_ADDR</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_PCIE_BAR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_BAR_SIZE</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -27020,24 +28073,8 @@
         </default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_LANES</id>
-		<default>48</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SLOT_NAME</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>SUBSYSTEM_DEVICE_ID</id>
@@ -27062,10 +28099,6 @@
 	<is_root>false</is_root>
 	<instance_name>phb4_x8_pci</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>PCIE</default>
@@ -27119,18 +28152,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -27151,16 +28172,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PCIE_LANE_GROUP</id>
@@ -27192,10 +28205,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -27218,10 +28227,6 @@
 	<child_id>phb4_x4</child_id>
 	<child_id>phb5_x4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -27242,18 +28247,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -27270,16 +28263,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>PCI_CONFIGS</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -27293,10 +28278,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -27314,10 +28295,6 @@
 	<instance_name>phb4_x4</instance_name>
 	<position>-1</position>
 	<child_id>phb4_x4_pci</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -27347,20 +28324,8 @@
 		<default>0x34C1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HDDW_ORDER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -27371,52 +28336,12 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MAX_POWER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MGC_LOAD_SOURCE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_CAPABILITES</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -27432,15 +28357,7 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_BAR_BASE_ADDR</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_PCIE_BAR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_BAR_SIZE</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -27462,24 +28379,8 @@
         </default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_LANES</id>
-		<default>48</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SLOT_NAME</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>SUBSYSTEM_DEVICE_ID</id>
@@ -27504,10 +28405,6 @@
 	<is_root>false</is_root>
 	<instance_name>phb4_x4_pci</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>PCIE</default>
@@ -27561,18 +28458,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -27593,16 +28478,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PCIE_LANE_GROUP</id>
@@ -27634,10 +28511,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -27657,10 +28530,6 @@
 	<instance_name>phb5_x4</instance_name>
 	<position>-1</position>
 	<child_id>phb5_x4_pci</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -27690,20 +28559,8 @@
 		<default>0x34C1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HDDW_ORDER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -27714,52 +28571,12 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MAX_POWER</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MGC_LOAD_SOURCE</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_32BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_DMA_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_64BIT_MMIO_SIZE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PCIE_CAPABILITES</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -27775,15 +28592,7 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_BAR_BASE_ADDR</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_PCIE_BAR_ENABLE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_PCIE_BAR_SIZE</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -27805,24 +28614,8 @@
         </default>
 	</attribute>
 	<attribute>
-		<id>PROC_PCIE_NUM_LANES</id>
-		<default>48</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>SLOT_NAME</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>SUBSYSTEM_DEVICE_ID</id>
@@ -27847,10 +28640,6 @@
 	<is_root>false</is_root>
 	<instance_name>phb5_x4_pci</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>PCIE</default>
@@ -27904,18 +28693,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -27936,16 +28713,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PCIE_LANE_GROUP</id>
@@ -27975,10 +28744,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -28819,10 +29584,6 @@
 	<instance_name>ppe0</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -28843,16 +29604,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -28867,16 +29620,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -28890,10 +29635,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -28910,10 +29651,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe10</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -28935,16 +29672,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -28959,16 +29688,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -28982,10 +29703,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29002,10 +29719,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe11</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29027,16 +29740,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29051,16 +29756,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29074,10 +29771,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29094,10 +29787,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe12</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29119,16 +29808,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29143,16 +29824,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29166,10 +29839,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29186,10 +29855,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe13</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29211,16 +29876,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29235,16 +29892,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29258,10 +29907,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29278,10 +29923,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe20</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29303,16 +29944,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29327,16 +29960,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29350,10 +29975,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29370,10 +29991,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe21</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29395,16 +30012,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29419,16 +30028,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29442,10 +30043,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29462,10 +30059,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe22</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29487,16 +30080,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29511,16 +30096,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29534,10 +30111,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29554,10 +30127,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe23</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29579,16 +30148,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29603,16 +30164,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29626,10 +30179,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29646,10 +30195,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe24</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29671,16 +30216,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29695,16 +30232,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29718,10 +30247,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29738,10 +30263,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe25</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29763,16 +30284,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29787,16 +30300,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29810,10 +30315,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29830,10 +30331,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe30</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29855,16 +30352,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29879,16 +30368,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29902,10 +30383,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -29922,10 +30399,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe31</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -29947,16 +30420,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -29971,16 +30436,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -29994,10 +30451,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30014,10 +30467,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe32</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30039,16 +30488,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30063,16 +30504,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30086,10 +30519,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30106,10 +30535,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe33</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30131,16 +30556,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30155,16 +30572,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30178,10 +30587,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30198,10 +30603,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe34</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30223,16 +30624,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30247,16 +30640,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30270,10 +30655,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30290,10 +30671,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe35</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30315,16 +30692,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30339,16 +30708,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30362,10 +30723,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30382,10 +30739,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe40</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30407,16 +30760,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30431,16 +30776,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30454,10 +30791,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30474,10 +30807,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe41</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30499,16 +30828,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30523,16 +30844,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30546,10 +30859,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30566,10 +30875,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe42</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30591,16 +30896,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30615,16 +30912,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30638,10 +30927,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30658,10 +30943,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe43</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30683,16 +30964,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30707,16 +30980,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30730,10 +30995,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30750,10 +31011,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe45</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30775,16 +31032,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30799,16 +31048,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30822,10 +31063,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30842,10 +31079,6 @@
 	<is_root>false</is_root>
 	<instance_name>ppe50</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30867,16 +31100,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30891,16 +31116,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -30914,10 +31131,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -30934,10 +31147,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv1</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -30959,16 +31168,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -30983,16 +31184,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31006,10 +31199,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31026,10 +31215,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv2</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31051,16 +31236,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31075,16 +31252,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31098,10 +31267,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31118,10 +31283,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv3</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31143,16 +31304,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31167,16 +31320,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31190,10 +31335,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31210,10 +31351,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv4</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31235,16 +31372,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31259,16 +31388,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31282,10 +31403,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31302,10 +31419,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv5</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31327,16 +31440,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31351,16 +31456,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31374,10 +31471,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31394,10 +31487,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv6</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31419,16 +31508,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31443,16 +31524,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31466,10 +31539,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31486,10 +31555,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv7</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31511,16 +31576,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31535,16 +31592,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31558,10 +31607,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31578,10 +31623,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv8</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31603,16 +31644,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31627,16 +31660,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31650,10 +31675,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31670,10 +31691,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv9</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31695,16 +31712,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31719,16 +31728,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31742,10 +31743,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31762,10 +31759,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv12</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31787,16 +31780,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31811,16 +31796,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31834,10 +31811,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31854,10 +31827,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv13</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31879,16 +31848,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31903,16 +31864,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -31926,10 +31879,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -31946,10 +31895,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv14</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -31971,16 +31916,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -31995,16 +31932,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32018,10 +31947,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32038,10 +31963,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv15</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32063,16 +31984,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32087,16 +32000,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32110,10 +32015,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32130,10 +32031,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv16</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32155,16 +32052,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32179,16 +32068,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32202,10 +32083,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32222,10 +32099,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv17</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32247,16 +32120,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32271,16 +32136,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32294,10 +32151,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32314,10 +32167,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv18</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32339,16 +32188,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32363,16 +32204,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32386,10 +32219,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32406,10 +32235,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv19</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32431,16 +32256,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32455,16 +32272,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32478,10 +32287,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32498,10 +32303,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv20</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32523,16 +32324,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32547,16 +32340,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32570,10 +32355,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32590,10 +32371,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv21</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32615,16 +32392,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32639,16 +32408,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32662,10 +32423,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32682,10 +32439,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv32</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32707,16 +32460,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32731,16 +32476,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32754,10 +32491,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32774,10 +32507,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv33</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32799,16 +32528,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32823,16 +32544,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32846,10 +32559,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32866,10 +32575,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv34</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32891,16 +32596,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -32915,16 +32612,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -32938,10 +32627,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -32958,10 +32643,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv35</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -32983,16 +32664,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33007,16 +32680,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33030,10 +32695,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33050,10 +32711,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv36</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33075,16 +32732,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33099,16 +32748,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33122,10 +32763,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33142,10 +32779,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv37</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33167,16 +32800,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33191,16 +32816,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33214,10 +32831,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33234,10 +32847,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv38</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33259,16 +32868,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33283,16 +32884,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33306,10 +32899,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33326,10 +32915,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv39</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33351,16 +32936,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33375,16 +32952,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33398,10 +32967,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33418,10 +32983,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv40</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33443,16 +33004,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33467,16 +33020,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33490,10 +33035,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33510,10 +33051,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv41</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33535,16 +33072,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33559,16 +33088,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33582,10 +33103,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33602,10 +33119,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv42</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33627,16 +33140,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33651,16 +33156,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33674,10 +33171,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33694,10 +33187,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv43</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33719,16 +33208,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33743,16 +33224,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33766,10 +33239,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33786,10 +33255,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv44</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33811,16 +33276,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33835,16 +33292,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33858,10 +33307,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33878,10 +33323,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv45</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33903,16 +33344,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -33927,16 +33360,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -33950,10 +33375,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -33970,10 +33391,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv46</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -33995,16 +33412,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34019,16 +33428,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34042,10 +33443,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34062,10 +33459,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv47</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -34087,16 +33480,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34111,16 +33496,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34134,10 +33511,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34154,10 +33527,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv48</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -34179,16 +33548,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34203,16 +33564,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34226,10 +33579,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34246,10 +33595,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv49</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -34271,16 +33616,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34295,16 +33632,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34318,10 +33647,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34338,10 +33663,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv50</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -34363,16 +33684,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34387,16 +33700,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34410,10 +33715,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34430,10 +33731,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv51</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -34455,16 +33752,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34479,16 +33768,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34502,10 +33783,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34522,10 +33799,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv52</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -34547,16 +33820,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34571,16 +33836,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34594,10 +33851,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34614,10 +33867,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv53</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -34639,16 +33888,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34663,16 +33904,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34686,10 +33919,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34706,10 +33935,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv54</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -34731,16 +33956,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34755,16 +33972,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34778,10 +33987,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34798,10 +34003,6 @@
 	<is_root>false</is_root>
 	<instance_name>perv55</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -34823,16 +34024,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34847,16 +34040,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -34870,10 +34055,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -34890,10 +34071,6 @@
 	<is_root>false</is_root>
 	<instance_name>xbus1</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>XBUS</default>
@@ -34923,20 +34100,12 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
+		<id>DUMMY_RW</id>
+		<default>5</default>
+	</attribute>
+	<attribute>
 		<id>EI_BUS_TX_MSBSWAP</id>
 		<default>0x00</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -34955,24 +34124,24 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IO_X_DEBUG</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>IO_X_MFG_CHK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_X_MFG_MIN_EYE_WIDTH</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -34992,10 +34161,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -35010,10 +34175,6 @@
 	<is_root>false</is_root>
 	<instance_name>xbus2</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>XBUS</default>
@@ -35043,20 +34204,12 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
+		<id>DUMMY_RW</id>
+		<default>5</default>
+	</attribute>
+	<attribute>
 		<id>EI_BUS_TX_MSBSWAP</id>
 		<default>0x80</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -35075,24 +34228,24 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>IO_X_DEBUG</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>IO_X_MFG_CHK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_X_MFG_MIN_EYE_WIDTH</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -35110,10 +34263,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -35134,10 +34283,6 @@
 	<child_id>obus-brick1</child_id>
 	<child_id>obus-brick2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default>affinity:sys-0/node-0/proc-0/obus-0</default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
 	</attribute>
@@ -35162,16 +34307,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>pu.obus:k0:n0:s0:p00:c0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default>0x00280000</default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -35182,12 +34319,32 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>NIMBUS</default>
+		<id>IO_OBUS_TX_FFE_POSTCURSOR</id>
+		<default>0x0</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
+		<id>IO_OBUS_TX_FFE_PRECURSOR</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_OBUS_TX_MARGIN_RATIO</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_DEBUG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_CHK</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_MIN_EYE_WIDTH</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -35196,14 +34353,6 @@
 	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
 		<default>NVLINK</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default>physical:sys-0/node-0/proc-0/perv-9</default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -35223,10 +34372,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -35241,10 +34386,6 @@
 	<is_root>false</is_root>
 	<instance_name>obus-brick0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
@@ -35274,16 +34415,8 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -35294,12 +34427,32 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>NIMBUS</default>
+		<id>IO_OBUS_TX_FFE_POSTCURSOR</id>
+		<default>0x0</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
+		<id>IO_OBUS_TX_FFE_PRECURSOR</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_OBUS_TX_MARGIN_RATIO</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_DEBUG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_CHK</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_MIN_EYE_WIDTH</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -35310,20 +34463,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>OBUS_SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
 		<default>NVLINK</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -35343,10 +34484,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -35361,10 +34498,6 @@
 	<is_root>false</is_root>
 	<instance_name>obus-brick1</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
@@ -35394,16 +34527,8 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -35414,12 +34539,32 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>NIMBUS</default>
+		<id>IO_OBUS_TX_FFE_POSTCURSOR</id>
+		<default>0x0</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
+		<id>IO_OBUS_TX_FFE_PRECURSOR</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_OBUS_TX_MARGIN_RATIO</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_DEBUG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_CHK</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_MIN_EYE_WIDTH</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -35430,20 +34575,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>OBUS_SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
 		<default>NVLINK</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -35463,10 +34596,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -35481,10 +34610,6 @@
 	<is_root>false</is_root>
 	<instance_name>obus-brick2</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
@@ -35514,16 +34639,8 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -35534,12 +34651,32 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>NIMBUS</default>
+		<id>IO_OBUS_TX_FFE_POSTCURSOR</id>
+		<default>0x0</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
+		<id>IO_OBUS_TX_FFE_PRECURSOR</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_OBUS_TX_MARGIN_RATIO</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_DEBUG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_CHK</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_MIN_EYE_WIDTH</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -35550,20 +34687,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>OBUS_SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
 		<default>NVLINK</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -35583,10 +34708,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -35604,10 +34725,6 @@
 	<child_id>obus-brick9</child_id>
 	<child_id>obus-brick10</child_id>
 	<child_id>obus-brick11</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default>affinity:sys-0/node-0/proc-0/obus-3</default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
@@ -35633,16 +34750,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>pu.obus:k0:n0:s0:p00:c3</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>3</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default>0x00280003</default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -35653,12 +34762,32 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>NIMBUS</default>
+		<id>IO_OBUS_TX_FFE_POSTCURSOR</id>
+		<default>0x0</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
+		<id>IO_OBUS_TX_FFE_PRECURSOR</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_OBUS_TX_MARGIN_RATIO</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_DEBUG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_CHK</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_MIN_EYE_WIDTH</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -35667,14 +34796,6 @@
 	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
 		<default>2</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default>physical:sys-0/node-0/proc-0/perv-12</default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -35694,10 +34815,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>3</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -35712,10 +34829,6 @@
 	<is_root>false</is_root>
 	<instance_name>obus-brick9</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
@@ -35745,16 +34858,8 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -35765,12 +34870,32 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>NIMBUS</default>
+		<id>IO_OBUS_TX_FFE_POSTCURSOR</id>
+		<default>0x0</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
+		<id>IO_OBUS_TX_FFE_PRECURSOR</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_OBUS_TX_MARGIN_RATIO</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_DEBUG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_CHK</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_MIN_EYE_WIDTH</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -35781,20 +34906,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>OBUS_SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
 		<default>NVLINK</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -35814,10 +34927,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -35832,10 +34941,6 @@
 	<is_root>false</is_root>
 	<instance_name>obus-brick10</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
@@ -35865,16 +34970,8 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -35885,12 +34982,32 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>NIMBUS</default>
+		<id>IO_OBUS_TX_FFE_POSTCURSOR</id>
+		<default>0x0</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
+		<id>IO_OBUS_TX_FFE_PRECURSOR</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_OBUS_TX_MARGIN_RATIO</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_DEBUG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_CHK</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_MIN_EYE_WIDTH</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -35901,20 +35018,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>OBUS_SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
 		<default>NVLINK</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -35934,10 +35039,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -35952,10 +35053,6 @@
 	<is_root>false</is_root>
 	<instance_name>obus-brick11</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
@@ -35985,16 +35082,8 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -36005,12 +35094,32 @@
 		<default>0x00000001</default>
 	</attribute>
 	<attribute>
-		<id>MODEL</id>
-		<default>NIMBUS</default>
+		<id>IO_OBUS_TX_FFE_POSTCURSOR</id>
+		<default>0x0</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
+		<id>IO_OBUS_TX_FFE_PRECURSOR</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_OBUS_TX_MARGIN_RATIO</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_DEBUG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_CHK</id>
 		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>IO_O_MFG_MIN_EYE_WIDTH</id>
+		<default>0x00</default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -36021,20 +35130,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>OBUS_SLOT_INDEX</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>OPTICS_CONFIG_MODE</id>
 		<default>NVLINK</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PEER_TARGET</id>
@@ -36054,10 +35151,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -36074,10 +35167,6 @@
 	<position>-1</position>
 	<child_id>mcs0</child_id>
 	<child_id>mcs1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>AVDD_ID</id>
 		<default>0</default>
@@ -36107,16 +35196,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -36131,20 +35212,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -36160,10 +35229,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -36173,10 +35238,6 @@
 	</attribute>
 	<attribute>
 		<id>VCS_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>VDDR_ID</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -36196,10 +35257,6 @@
 	<position>-1</position>
 	<child_id>mca0</child_id>
 	<child_id>mca1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -36225,8 +35282,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>DMI_REFCLOCK_SWIZZLE</id>
-		<default>0</default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>
@@ -36247,18 +35304,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -36271,27 +35316,15 @@
 		<default>0x0003E00000000000</default>
 	</attribute>
 	<attribute>
-		<id>MEMVPD_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
+		<id>MSS_MRW_UNSUPPORTED_RANK_CONFIG</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -36308,20 +35341,12 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
 		<default>MCS</default>
-	</attribute>
-	<attribute>
-		<id>VPD_REC_NUM</id>
-		<default>0xFFFF</default>
 	</attribute>
 </targetInstance>
 <targetInstance>
@@ -36332,10 +35357,6 @@
 	<position>-1</position>
 	<child_id>ddr_ch0:cs0</child_id>
 	<child_id>ddr_ch0:cs1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -36361,16 +35382,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -36385,20 +35398,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -36418,10 +35419,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -36436,10 +35433,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch0:cs0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -36465,18 +35458,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -36497,16 +35478,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -36520,10 +35493,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -36544,10 +35513,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch0:cs1</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -36573,18 +35538,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -36605,16 +35558,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -36628,10 +35573,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -36654,10 +35595,6 @@
 	<position>-1</position>
 	<child_id>ddr_ch1:cs0</child_id>
 	<child_id>ddr_ch1:cs1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -36683,16 +35620,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -36707,20 +35636,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -36740,10 +35657,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -36758,10 +35671,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch1:cs0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -36787,18 +35696,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -36819,16 +35716,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -36842,10 +35731,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -36866,10 +35751,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch1:cs1</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -36895,18 +35776,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -36927,16 +35796,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -36950,10 +35811,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -36976,10 +35833,6 @@
 	<position>-1</position>
 	<child_id>mca2</child_id>
 	<child_id>mca3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -37005,8 +35858,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>DMI_REFCLOCK_SWIZZLE</id>
-		<default>0</default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>
@@ -37027,18 +35880,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -37051,27 +35892,15 @@
 		<default>0x0003E00000000000</default>
 	</attribute>
 	<attribute>
-		<id>MEMVPD_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
+		<id>MSS_MRW_UNSUPPORTED_RANK_CONFIG</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -37088,20 +35917,12 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
 		<default>MCS</default>
-	</attribute>
-	<attribute>
-		<id>VPD_REC_NUM</id>
-		<default>0xFFFF</default>
 	</attribute>
 </targetInstance>
 <targetInstance>
@@ -37112,10 +35933,6 @@
 	<position>-1</position>
 	<child_id>ddr_ch2:cs0</child_id>
 	<child_id>ddr_ch2:cs1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -37141,16 +35958,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -37165,20 +35974,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -37198,10 +35995,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -37216,10 +36009,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch2:cs0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -37245,18 +36034,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -37277,16 +36054,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -37300,10 +36069,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -37325,10 +36090,6 @@
 	<instance_name>ddr_ch2:cs1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
 	</attribute>
@@ -37353,18 +36114,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -37385,16 +36134,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -37408,10 +36149,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -37434,10 +36171,6 @@
 	<position>-1</position>
 	<child_id>ddr_ch3:cs0</child_id>
 	<child_id>ddr_ch3:cs1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -37463,16 +36196,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -37487,20 +36212,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -37520,10 +36233,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -37538,10 +36247,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch3:cs0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -37567,18 +36272,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -37599,16 +36292,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -37622,10 +36307,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -37647,10 +36328,6 @@
 	<instance_name>ddr_ch3:cs1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
 	</attribute>
@@ -37675,18 +36352,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -37707,16 +36372,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -37730,10 +36387,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -37756,10 +36409,6 @@
 	<position>-1</position>
 	<child_id>mcs2</child_id>
 	<child_id>mcs3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>AVDD_ID</id>
 		<default>0</default>
@@ -37789,16 +36438,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -37813,20 +36454,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -37842,10 +36471,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -37855,10 +36480,6 @@
 	</attribute>
 	<attribute>
 		<id>VCS_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>VDDR_ID</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -37878,10 +36499,6 @@
 	<position>-1</position>
 	<child_id>mca4</child_id>
 	<child_id>mca5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -37907,8 +36524,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>DMI_REFCLOCK_SWIZZLE</id>
-		<default>0</default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>
@@ -37929,18 +36546,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -37953,27 +36558,15 @@
 		<default>0x0003E00000000000</default>
 	</attribute>
 	<attribute>
-		<id>MEMVPD_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
+		<id>MSS_MRW_UNSUPPORTED_RANK_CONFIG</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -37990,20 +36583,12 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
 		<default>MCS</default>
-	</attribute>
-	<attribute>
-		<id>VPD_REC_NUM</id>
-		<default>0xFFFF</default>
 	</attribute>
 </targetInstance>
 <targetInstance>
@@ -38014,10 +36599,6 @@
 	<position>-1</position>
 	<child_id>ddr_ch4:cs0</child_id>
 	<child_id>ddr_ch4:cs1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -38043,16 +36624,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -38067,20 +36640,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -38100,10 +36661,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -38118,10 +36675,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch4:cs0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -38147,18 +36700,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -38179,16 +36720,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -38202,10 +36735,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -38227,10 +36756,6 @@
 	<instance_name>ddr_ch4:cs1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
 	</attribute>
@@ -38255,18 +36780,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -38287,16 +36800,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -38310,10 +36815,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -38336,10 +36837,6 @@
 	<position>-1</position>
 	<child_id>ddr_ch5:cs0</child_id>
 	<child_id>ddr_ch5:cs1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -38365,16 +36862,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -38389,20 +36878,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -38422,10 +36899,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -38440,10 +36913,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch5:cs0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -38469,18 +36938,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -38501,16 +36958,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -38524,10 +36973,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -38549,10 +36994,6 @@
 	<instance_name>ddr_ch5:cs1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
 	</attribute>
@@ -38577,18 +37018,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -38609,16 +37038,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -38632,10 +37053,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -38658,10 +37075,6 @@
 	<position>-1</position>
 	<child_id>mca6</child_id>
 	<child_id>mca7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -38687,8 +37100,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>DMI_REFCLOCK_SWIZZLE</id>
-		<default>0</default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>
@@ -38709,18 +37122,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -38733,27 +37134,15 @@
 		<default>0x0003E00000000000</default>
 	</attribute>
 	<attribute>
-		<id>MEMVPD_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>MODEL</id>
 		<default>NIMBUS</default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
+		<id>MSS_MRW_UNSUPPORTED_RANK_CONFIG</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -38770,20 +37159,12 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
 		<default>MCS</default>
-	</attribute>
-	<attribute>
-		<id>VPD_REC_NUM</id>
-		<default>0xFFFF</default>
 	</attribute>
 </targetInstance>
 <targetInstance>
@@ -38794,10 +37175,6 @@
 	<position>-1</position>
 	<child_id>ddr_ch6:cs0</child_id>
 	<child_id>ddr_ch6:cs1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -38823,16 +37200,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -38847,20 +37216,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -38880,10 +37237,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -38898,10 +37251,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch6:cs0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -38927,18 +37276,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -38959,16 +37296,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -38982,10 +37311,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -39007,10 +37332,6 @@
 	<instance_name>ddr_ch6:cs1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
 	</attribute>
@@ -39035,18 +37356,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -39067,16 +37376,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -39090,10 +37391,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -39116,10 +37413,6 @@
 	<position>-1</position>
 	<child_id>ddr_ch7:cs0</child_id>
 	<child_id>ddr_ch7:cs1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -39145,16 +37438,8 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -39169,20 +37454,8 @@
 		<default>NIMBUS</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PARENT_PERVASIVE</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -39202,10 +37475,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
@@ -39220,10 +37489,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr_ch7:cs0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -39249,18 +37514,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -39281,16 +37534,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -39304,10 +37549,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -39329,10 +37570,6 @@
 	<instance_name>ddr_ch7:cs1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
 	</attribute>
@@ -39357,18 +37594,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -39389,16 +37614,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -39412,10 +37629,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -39437,10 +37650,6 @@
 	<instance_name>fsi-slave-0</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSIM</default>
 	</attribute>
@@ -39469,20 +37678,8 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_PORT</id>
 		<default>0x00</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -39497,16 +37694,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -39520,10 +37709,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -39541,10 +37726,6 @@
 	<instance_name>fsi-slave-1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSIM</default>
 	</attribute>
@@ -39573,20 +37754,8 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_PORT</id>
 		<default>0x00</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -39601,16 +37770,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -39624,10 +37785,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -39645,10 +37802,6 @@
 	<instance_name>fsi-cm-0</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSICM</default>
 	</attribute>
@@ -39677,14 +37830,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_ENGINE</id>
 		<default>0x0C</default>
 	</attribute>
@@ -39695,10 +37840,6 @@
 	<attribute>
 		<id>FSI_PORT</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -39713,16 +37854,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSICM</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -39736,10 +37869,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -39757,10 +37886,6 @@
 	<instance_name>fsi-cm-1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSICM</default>
 	</attribute>
@@ -39789,14 +37914,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_ENGINE</id>
 		<default>0x0C</default>
 	</attribute>
@@ -39807,10 +37924,6 @@
 	<attribute>
 		<id>FSI_PORT</id>
 		<default>1</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -39825,16 +37938,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSICM</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -39848,10 +37953,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -39869,10 +37970,6 @@
 	<instance_name>fsi-cm-2</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSICM</default>
 	</attribute>
@@ -39901,14 +37998,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_ENGINE</id>
 		<default>0x0C</default>
 	</attribute>
@@ -39919,10 +38008,6 @@
 	<attribute>
 		<id>FSI_PORT</id>
 		<default>2</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -39937,16 +38022,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSICM</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -39960,10 +38037,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -39981,10 +38054,6 @@
 	<instance_name>fsi-cm-3</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSICM</default>
 	</attribute>
@@ -40013,14 +38082,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_ENGINE</id>
 		<default>0x0C</default>
 	</attribute>
@@ -40031,10 +38092,6 @@
 	<attribute>
 		<id>FSI_PORT</id>
 		<default>3</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -40049,16 +38106,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSICM</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -40072,10 +38121,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -40093,10 +38138,6 @@
 	<instance_name>fsim-0</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSIM</default>
 	</attribute>
@@ -40125,14 +38166,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_ENGINE</id>
 		<default>0x0D</default>
 	</attribute>
@@ -40143,10 +38176,6 @@
 	<attribute>
 		<id>FSI_PORT</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -40161,16 +38190,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSIM</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -40184,10 +38205,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -40205,10 +38222,6 @@
 	<instance_name>fsim-1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSIM</default>
 	</attribute>
@@ -40237,14 +38250,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_ENGINE</id>
 		<default>0x0D</default>
 	</attribute>
@@ -40255,10 +38260,6 @@
 	<attribute>
 		<id>FSI_PORT</id>
 		<default>1</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -40273,16 +38274,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSIM</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -40296,10 +38289,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -40317,10 +38306,6 @@
 	<instance_name>fsim-2</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSIM</default>
 	</attribute>
@@ -40349,14 +38334,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_ENGINE</id>
 		<default>0x0D</default>
 	</attribute>
@@ -40367,10 +38344,6 @@
 	<attribute>
 		<id>FSI_PORT</id>
 		<default>2</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -40385,16 +38358,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSIM</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -40408,10 +38373,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -41792,10 +39753,6 @@
 	<hidden_child_id>dimm_temp_sensor</hidden_child_id>
 	<hidden_child_id>dimm_func_sensor</hidden_child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>CARD_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -41804,12 +39761,36 @@
 		<default>DIMM</default>
 	</attribute>
 	<attribute>
+		<id>CEN_BAD_DQ_BITMAP</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CEN_DQ_TO_DIMM_CONN_DQ</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CEN_MBA_DIMM</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CEN_MBA_PORT</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CEN_VPD_VERSION</id>
+		<default></default>
+	</attribute>
+	<attribute>
 		<id>CLASS</id>
 		<default>LOGICAL_CARD</default>
 	</attribute>
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>1</default>
+	</attribute>
+	<attribute>
+		<id>DUMMY_RW</id>
+		<default>5</default>
 	</attribute>
 	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>
@@ -41826,23 +39807,11 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>4</default>
 	</attribute>
 	<attribute>
 		<id>FRU_NAME</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
 		<default></default>
 	</attribute>
 	<attribute>
@@ -41886,10 +39855,6 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>PART_NUMBER</id>
 		<default></default>
 	</attribute>
@@ -41909,10 +39874,6 @@
 				<field><id>supportsInbandScom</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -41939,10 +39900,6 @@
 		<id>TYPE</id>
 		<default>DIMM</default>
 	</attribute>
-	<attribute>
-		<id>VPD_REC_NUM</id>
-		<default>0xFFFF</default>
-	</attribute>
 </targetInstance>
 <targetInstance>
 	<id>ddr4</id>
@@ -41950,10 +39907,6 @@
 	<is_root>false</is_root>
 	<instance_name>ddr4</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>DDR4</default>
@@ -41979,18 +39932,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default>0x0</default>
 	</attribute>
@@ -42003,16 +39944,8 @@
 		<default>JEDEC</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -42026,10 +39959,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -42104,18 +40033,6 @@
 	<position>-1</position>
 	<child_id>dimm-thermal-sensor.i2c</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>CLASS</id>
 		<default>CHIP</default>
 	</attribute>
@@ -42124,28 +40041,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
 	</attribute>
 	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
@@ -42153,14 +40050,6 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -42175,16 +40064,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -43048,10 +40929,6 @@
 	<child_id>perst2</child_id>
 	<child_id>presence2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>CARD_TYPE</id>
 		<default>GENERIC_PCIE</default>
 	</attribute>
@@ -43062,18 +40939,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -43090,10 +40955,6 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -44392,18 +42253,6 @@
 	<child_id>chip-bmc-ast2500.pin_C2_rgmii2_rmii2_gpiov2u3</child_id>
 	<child_id>chip-bmc-ast2500.pin_L20_perst</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>BMC_HW_CHIP_TYPE</id>
 		<default>ast2500</default>
 	</attribute>
@@ -44428,28 +42277,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
 	</attribute>
 	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
@@ -44457,14 +42286,6 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -44491,16 +42312,8 @@
 		<default>AST2500</default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -44549,10 +42362,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc0</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiow0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -44573,18 +42382,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -44601,16 +42398,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -44624,10 +42413,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -44645,10 +42430,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc0,NA,NA,NA,NA,NA,NA,NA</default>
@@ -44674,18 +42455,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -44702,16 +42471,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -44725,10 +42486,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -44745,10 +42502,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc0</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -44774,18 +42527,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -44802,16 +42543,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -44825,10 +42558,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -44846,10 +42575,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiow0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOW0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -44875,18 +42600,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -44903,16 +42616,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -44926,10 +42631,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -45012,10 +42713,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc1</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiow1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -45036,18 +42733,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -45064,16 +42749,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -45087,10 +42764,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -45108,10 +42781,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc1,NA,NA,NA,NA,NA,NA,NA</default>
@@ -45137,18 +42806,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -45165,16 +42822,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -45188,10 +42837,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -45208,10 +42853,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc1</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -45237,18 +42878,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -45265,16 +42894,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -45288,10 +42909,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -45309,10 +42926,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiow1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOW1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -45338,18 +42951,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -45366,16 +42967,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -45389,10 +42982,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -45475,10 +43064,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc2</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiow2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -45499,18 +43084,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -45527,16 +43100,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -45550,10 +43115,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -45571,10 +43132,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc2,NA,NA,NA,NA,NA,NA,NA</default>
@@ -45600,18 +43157,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -45628,16 +43173,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -45651,10 +43188,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -45671,10 +43204,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc2</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -45700,18 +43229,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -45728,16 +43245,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -45751,10 +43260,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -45772,10 +43277,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiow2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOW2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -45801,18 +43302,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -45829,16 +43318,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -45852,10 +43333,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -45938,10 +43415,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiow3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -45962,18 +43435,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -45990,16 +43451,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -46013,10 +43466,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -46034,10 +43483,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc3,NA,NA,NA,NA,NA,NA,NA</default>
@@ -46063,18 +43508,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -46091,16 +43524,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -46114,10 +43539,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -46134,10 +43555,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc3</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -46163,18 +43580,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -46191,16 +43596,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -46214,10 +43611,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -46235,10 +43628,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiow3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOW3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -46264,18 +43653,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -46292,16 +43669,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -46315,10 +43684,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -46401,10 +43766,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc4</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiow4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -46425,18 +43786,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -46453,16 +43802,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -46476,10 +43817,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -46497,10 +43834,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc4,NA,NA,NA,NA,NA,NA,NA</default>
@@ -46526,18 +43859,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -46554,16 +43875,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -46577,10 +43890,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -46597,10 +43906,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc4</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -46626,18 +43931,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -46654,16 +43947,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -46677,10 +43962,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -46698,10 +43979,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiow4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOW4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -46727,18 +44004,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -46755,16 +44020,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -46778,10 +44035,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -46864,10 +44117,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc5</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiow5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -46888,18 +44137,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -46916,16 +44153,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -46939,10 +44168,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -46960,10 +44185,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc5,NA,NA,NA,NA,NA,NA,NA</default>
@@ -46989,18 +44210,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -47017,16 +44226,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -47040,10 +44241,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -47060,10 +44257,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc5</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -47089,18 +44282,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -47117,16 +44298,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -47140,10 +44313,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -47161,10 +44330,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiow5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOW5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -47190,18 +44355,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -47218,16 +44371,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -47241,10 +44386,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -47327,10 +44468,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc6</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiow6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -47351,18 +44488,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -47379,16 +44504,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -47402,10 +44519,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -47423,10 +44536,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc6,NA,NA,NA,NA,NA,NA,NA</default>
@@ -47452,18 +44561,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -47480,16 +44577,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -47503,10 +44592,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -47523,10 +44608,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc6</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -47552,18 +44633,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -47580,16 +44649,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -47603,10 +44664,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -47624,10 +44681,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiow6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOW6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -47653,18 +44706,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -47681,16 +44722,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -47704,10 +44737,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -47790,10 +44819,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiow7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -47814,18 +44839,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -47842,16 +44855,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -47865,10 +44870,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -47886,10 +44887,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc7,NA,NA,NA,NA,NA,NA,NA</default>
@@ -47915,18 +44912,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -47943,16 +44928,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -47966,10 +44943,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -47986,10 +44959,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc7</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -48015,18 +44984,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -48043,16 +45000,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -48066,10 +45015,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -48087,10 +45032,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiow7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOW7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -48116,18 +45057,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -48144,16 +45073,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -48167,10 +45088,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -48253,10 +45170,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc8</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiox0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -48277,18 +45190,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -48305,16 +45206,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -48328,10 +45221,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -48349,10 +45238,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc8</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc8</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc8,NA,NA,NA,NA,NA,NA,NA</default>
@@ -48378,18 +45263,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -48406,16 +45279,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -48429,10 +45294,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -48449,10 +45310,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc8</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -48478,18 +45335,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -48506,16 +45351,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -48529,10 +45366,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -48550,10 +45383,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiox0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOX0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -48579,18 +45408,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -48607,16 +45424,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -48630,10 +45439,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -48716,10 +45521,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc9</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiox1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -48740,18 +45541,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -48768,16 +45557,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -48791,10 +45572,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -48812,10 +45589,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc9</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc9</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc9,NA,NA,NA,NA,NA,NA,NA</default>
@@ -48841,18 +45614,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -48869,16 +45630,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -48892,10 +45645,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -48912,10 +45661,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc9</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -48941,18 +45686,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -48969,16 +45702,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -48992,10 +45717,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -49013,10 +45734,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiox1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOX1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -49042,18 +45759,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -49070,16 +45775,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -49093,10 +45790,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -49179,10 +45872,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc10</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiox2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -49203,18 +45892,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -49231,16 +45908,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -49254,10 +45923,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -49275,10 +45940,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc10</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc10</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc10,NA,NA,NA,NA,NA,NA,NA</default>
@@ -49304,18 +45965,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -49332,16 +45981,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -49355,10 +45996,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -49375,10 +46012,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc10</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -49404,18 +46037,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -49432,16 +46053,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -49455,10 +46068,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -49476,10 +46085,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiox2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOX2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -49505,18 +46110,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -49533,16 +46126,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -49556,10 +46141,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -49642,10 +46223,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc11</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiox3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -49666,18 +46243,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -49694,16 +46259,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -49717,10 +46274,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -49738,10 +46291,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc11</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc11</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc11,NA,NA,NA,NA,NA,NA,NA</default>
@@ -49767,18 +46316,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -49795,16 +46332,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -49818,10 +46347,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -49838,10 +46363,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc11</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -49867,18 +46388,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -49895,16 +46404,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -49918,10 +46419,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -49939,10 +46436,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiox3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOX3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -49968,18 +46461,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -49996,16 +46477,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -50019,10 +46492,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -50105,10 +46574,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc12</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiox4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -50129,18 +46594,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -50157,16 +46610,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -50180,10 +46625,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -50201,10 +46642,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc12</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc12</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc12,NA,NA,NA,NA,NA,NA,NA</default>
@@ -50230,18 +46667,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -50258,16 +46683,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -50281,10 +46698,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -50301,10 +46714,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc12</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -50330,18 +46739,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -50358,16 +46755,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -50381,10 +46770,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -50402,10 +46787,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiox4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOX4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -50431,18 +46812,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -50459,16 +46828,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -50482,10 +46843,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -50568,10 +46925,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc13</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiox5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -50592,18 +46945,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -50620,16 +46961,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -50643,10 +46976,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -50664,10 +46993,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc13</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc13</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc13,NA,NA,NA,NA,NA,NA,NA</default>
@@ -50693,18 +47018,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -50721,16 +47034,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -50744,10 +47049,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -50764,10 +47065,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc13</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -50793,18 +47090,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -50821,16 +47106,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -50844,10 +47121,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -50865,10 +47138,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiox5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOX5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -50894,18 +47163,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -50922,16 +47179,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -50945,10 +47194,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -51031,10 +47276,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc14</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiox6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -51055,18 +47296,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -51083,16 +47312,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -51106,10 +47327,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -51127,10 +47344,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc14</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc14</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc14,NA,NA,NA,NA,NA,NA,NA</default>
@@ -51156,18 +47369,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -51184,16 +47385,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -51207,10 +47400,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -51227,10 +47416,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc14</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -51256,18 +47441,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -51284,16 +47457,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -51307,10 +47472,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -51328,10 +47489,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiox6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOX6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -51357,18 +47514,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -51385,16 +47530,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -51408,10 +47545,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -51494,10 +47627,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_adc15</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiox7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -51518,18 +47647,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -51546,16 +47663,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -51569,10 +47678,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -51590,10 +47695,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_adc15</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.adc15</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>adc15,NA,NA,NA,NA,NA,NA,NA</default>
@@ -51619,18 +47720,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -51647,16 +47736,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -51670,10 +47751,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -51690,10 +47767,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.adc15</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -51719,18 +47792,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -51747,16 +47808,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -51770,10 +47823,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -51791,10 +47840,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiox7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOX7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -51820,18 +47865,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -51848,16 +47881,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -51871,10 +47896,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -51956,10 +47977,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_dac</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -51980,18 +47997,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -52008,16 +48013,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52031,10 +48028,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -52053,10 +48046,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.dac</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -52081,18 +48070,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -52109,16 +48086,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52132,10 +48101,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -52152,10 +48117,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.dac</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -52177,18 +48138,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -52205,16 +48154,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52228,10 +48169,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -52250,10 +48187,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_peci</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -52274,18 +48207,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -52302,16 +48223,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52325,10 +48238,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -52347,10 +48256,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.peci</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -52375,18 +48280,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -52403,16 +48296,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52426,10 +48311,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -52446,10 +48327,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.peci</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -52469,18 +48346,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -52499,16 +48364,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52522,10 +48379,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -52543,10 +48396,6 @@
 	<instance_name>chip-bmc-ast2500.pin_C7_usb</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_usb</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -52568,18 +48417,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -52596,16 +48433,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52619,10 +48448,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -52640,10 +48465,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_usb</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.usb</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -52669,18 +48490,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -52697,16 +48506,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52720,10 +48521,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -52795,10 +48592,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_pcie</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -52819,18 +48612,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -52847,16 +48628,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52870,10 +48643,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -52891,10 +48660,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_pcie</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pcie</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -52920,18 +48685,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -52948,16 +48701,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -52971,10 +48716,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -53024,10 +48765,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_jtag</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -53048,18 +48785,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -53076,16 +48801,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -53099,10 +48816,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -53120,10 +48833,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_jtag</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.jtag</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -53149,18 +48858,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -53177,16 +48874,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -53200,10 +48889,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -53253,10 +48938,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_uart5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -53277,18 +48958,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -53305,16 +48974,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -53328,10 +48989,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -53349,10 +49006,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_uart5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.UART5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -53378,18 +49031,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -53406,16 +49047,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -53429,10 +49062,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -53482,10 +49111,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_fwspi</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -53506,18 +49131,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -53534,16 +49147,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -53557,10 +49162,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -53578,10 +49179,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_fwspi</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.fwspi</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -53607,18 +49204,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -53635,16 +49220,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -53658,10 +49235,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -53723,10 +49296,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioa0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -53747,18 +49316,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -53775,16 +49332,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -53798,10 +49347,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -53819,10 +49364,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioa0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOA0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -53848,18 +49389,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -53876,16 +49405,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -53899,10 +49420,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -53984,10 +49501,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioa1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -54008,18 +49521,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -54036,16 +49537,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -54059,10 +49552,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -54080,10 +49569,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioa1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOA1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -54109,18 +49594,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -54137,16 +49610,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -54160,10 +49625,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -54246,10 +49707,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioa2</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_timer3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -54270,18 +49727,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -54298,16 +49743,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -54321,10 +49758,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -54342,10 +49775,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioa2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOA2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -54371,18 +49800,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -54399,16 +49816,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -54422,10 +49831,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -54507,10 +49912,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TIMER3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>timer3,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -54535,18 +49936,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -54563,16 +49952,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -54586,10 +49967,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -54606,10 +49983,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.TIMER3</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -54631,18 +50004,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -54659,16 +50020,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -54682,10 +50035,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -54705,10 +50054,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioa3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_timer4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -54729,18 +50074,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -54757,16 +50090,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -54780,10 +50105,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -54801,10 +50122,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioa3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOA3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -54830,18 +50147,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -54858,16 +50163,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -54881,10 +50178,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -54966,10 +50259,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TIMER4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>timer4,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -54994,18 +50283,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -55022,16 +50299,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -55045,10 +50314,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -55065,10 +50330,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.TIMER4</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -55090,18 +50351,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -55118,16 +50367,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -55141,10 +50382,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -55165,10 +50402,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_timer5</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c9</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -55189,18 +50422,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -55217,16 +50438,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -55240,10 +50453,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -55261,10 +50470,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioa4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOA4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -55290,18 +50495,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -55318,16 +50511,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -55341,10 +50526,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -55426,10 +50607,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TIMER5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>timer5,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -55454,18 +50631,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -55482,16 +50647,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -55505,10 +50662,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -55525,10 +50678,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.TIMER5</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -55550,18 +50699,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -55578,16 +50715,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -55601,10 +50730,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -55622,10 +50747,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_i2c9</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C9</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -55651,18 +50772,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -55679,16 +50788,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -55702,10 +50803,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -55776,10 +50873,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioa6</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_timer7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -55800,18 +50893,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -55828,16 +50909,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -55851,10 +50924,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -55872,10 +50941,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioa6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOA6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -55901,18 +50966,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -55929,16 +50982,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -55952,10 +50997,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -56037,10 +51078,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TIMER7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>timer7,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -56065,18 +51102,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -56093,16 +51118,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -56116,10 +51133,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -56136,10 +51149,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.TIMER7</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -56161,18 +51170,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -56189,16 +51186,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -56212,10 +51201,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -56235,10 +51220,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioa7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_timer8</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -56259,18 +51240,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -56287,16 +51256,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -56310,10 +51271,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -56331,10 +51288,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioa7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOA7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -56360,18 +51313,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -56388,16 +51329,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -56411,10 +51344,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -56496,10 +51425,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TIMER8</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>timer8,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -56524,18 +51449,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -56552,16 +51465,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -56575,10 +51480,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -56595,10 +51496,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.TIMER8</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -56618,18 +51515,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -56648,16 +51533,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -56671,10 +51548,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -56692,10 +51565,6 @@
 	<instance_name>chip-bmc-ast2500.pin_K19_gpiob0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpiob0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -56717,18 +51586,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -56745,16 +51602,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -56768,10 +51617,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -56789,10 +51634,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiob0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOB0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -56818,18 +51659,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -56846,16 +51675,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -56869,10 +51690,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -56954,10 +51771,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpiob1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -56978,18 +51791,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -57006,16 +51807,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -57029,10 +51822,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -57050,10 +51839,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiob1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOB1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -57079,18 +51864,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -57107,16 +51880,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -57130,10 +51895,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -57215,10 +51976,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpiob2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -57239,18 +51996,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -57267,16 +52012,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -57290,10 +52027,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -57311,10 +52044,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiob2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOB2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -57340,18 +52069,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -57368,16 +52085,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -57391,10 +52100,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -57476,10 +52181,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpiob3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -57500,18 +52201,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -57528,16 +52217,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -57551,10 +52232,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -57572,10 +52249,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiob3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOB3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -57601,18 +52274,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -57629,16 +52290,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -57652,10 +52305,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -57737,10 +52386,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpiob4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -57761,18 +52406,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -57789,16 +52422,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -57812,10 +52437,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -57833,10 +52454,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiob4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOB4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -57862,18 +52479,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -57890,16 +52495,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -57913,10 +52510,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -57998,10 +52591,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpiob5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -58022,18 +52611,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -58050,16 +52627,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -58073,10 +52642,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -58094,10 +52659,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiob5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOB5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -58123,18 +52684,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -58151,16 +52700,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -58174,10 +52715,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -58259,10 +52796,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpiob6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -58283,18 +52816,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -58311,16 +52832,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -58334,10 +52847,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -58355,10 +52864,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiob6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOB6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -58384,18 +52889,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -58412,16 +52905,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -58435,10 +52920,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -58520,10 +53001,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpiob7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -58544,18 +53021,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -58572,16 +53037,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -58595,10 +53052,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -58616,10 +53069,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiob7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOB7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -58645,18 +53094,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -58673,16 +53110,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -58696,10 +53125,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -58783,10 +53208,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_sd1</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c10111213</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -58807,18 +53228,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -58835,16 +53244,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -58858,10 +53259,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -58887,10 +53284,6 @@
 	<child_id>chip-bmc-ast2500.GPIOC6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOC7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -58915,18 +53308,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -58943,16 +53324,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -58966,10 +53339,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -59492,10 +53861,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.SD1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -59520,18 +53885,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -59548,16 +53901,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -59571,10 +53916,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -59591,10 +53932,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.SD1</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -59616,18 +53953,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -59644,16 +53969,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -59667,10 +53984,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -59692,10 +54005,6 @@
 	<child_id>chip-bmc-ast2500.I2C12</child_id>
 	<child_id>chip-bmc-ast2500.I2C13</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -59720,18 +54029,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -59748,16 +54045,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -59771,10 +54060,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -59998,10 +54283,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiod0d7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_sd2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -60022,18 +54303,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -60050,16 +54319,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -60073,10 +54334,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -60102,10 +54359,6 @@
 	<child_id>chip-bmc-ast2500.GPIOD6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOD7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -60130,18 +54383,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -60158,16 +54399,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -60181,10 +54414,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -60707,10 +54936,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.SD2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -60735,18 +54960,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -60763,16 +54976,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -60786,10 +54991,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -60806,10 +55007,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.SD2</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -60831,18 +55028,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -60859,16 +55044,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -60882,10 +55059,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -60905,10 +55078,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioe0e7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_uart3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -60929,18 +55098,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -60957,16 +55114,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -60980,10 +55129,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -61009,10 +55154,6 @@
 	<child_id>chip-bmc-ast2500.GPIOE6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOE7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -61037,18 +55178,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -61065,16 +55194,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -61088,10 +55209,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -61614,10 +55731,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.UART3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -61642,18 +55755,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -61670,16 +55771,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -61693,10 +55786,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -61747,10 +55836,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiof0f7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_uart4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -61771,18 +55856,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -61799,16 +55872,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -61822,10 +55887,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -61851,10 +55912,6 @@
 	<child_id>chip-bmc-ast2500.GPIOF6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOF7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -61879,18 +55936,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -61907,16 +55952,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -61930,10 +55967,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -62456,10 +56489,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.UART4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -62484,18 +56513,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -62512,16 +56529,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -62535,10 +56544,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -62589,10 +56594,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiog0g3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_sgps1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -62613,18 +56614,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -62641,16 +56630,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -62664,10 +56645,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -62688,10 +56665,6 @@
 	<child_id>chip-bmc-ast2500.GPIOG1</child_id>
 	<child_id>chip-bmc-ast2500.GPIOG2</child_id>
 	<child_id>chip-bmc-ast2500.GPIOG3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -62717,18 +56690,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -62745,16 +56706,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -62768,10 +56721,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -63042,10 +56991,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.SGPS1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -63070,18 +57015,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -63098,16 +57031,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -63121,10 +57046,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -63141,10 +57062,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.SGPS1</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -63166,18 +57083,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -63194,16 +57099,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -63217,10 +57114,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -63240,10 +57133,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiog4g7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_sgps2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -63264,18 +57153,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -63292,16 +57169,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -63315,10 +57184,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -63340,10 +57205,6 @@
 	<child_id>chip-bmc-ast2500.GPIOG6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOG7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -63368,18 +57229,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -63396,16 +57245,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -63419,10 +57260,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -63693,10 +57530,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.SGPS2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -63721,18 +57554,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -63749,16 +57570,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -63772,10 +57585,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -63792,10 +57601,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.SGPS2</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -63817,18 +57622,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -63845,16 +57638,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -63868,10 +57653,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -63890,10 +57671,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioh0h7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_uart6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -63915,18 +57692,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -63943,16 +57708,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -63966,10 +57723,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -63995,10 +57748,6 @@
 	<child_id>chip-bmc-ast2500.GPIOH6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOH7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -64023,18 +57772,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -64051,16 +57788,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -64074,10 +57803,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -64600,10 +58325,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.UART6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -64628,18 +58349,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -64656,16 +58365,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -64679,10 +58380,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -64733,10 +58430,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioi0i3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_sysspi</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -64757,18 +58450,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -64785,16 +58466,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -64808,10 +58481,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -64832,10 +58501,6 @@
 	<child_id>chip-bmc-ast2500.GPIOI1</child_id>
 	<child_id>chip-bmc-ast2500.GPIOI2</child_id>
 	<child_id>chip-bmc-ast2500.GPIOI3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -64861,18 +58526,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -64889,16 +58542,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -64912,10 +58557,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -65186,10 +58827,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.SYSSPI</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -65214,18 +58851,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -65242,16 +58867,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -65265,10 +58882,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -65327,10 +58940,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioi4i7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_spi1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -65351,18 +58960,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -65379,16 +58976,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -65402,10 +58991,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -65426,10 +59011,6 @@
 	<child_id>chip-bmc-ast2500.GPIOI5</child_id>
 	<child_id>chip-bmc-ast2500.GPIOI6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOI7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -65455,18 +59036,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -65483,16 +59052,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -65506,10 +59067,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -65780,10 +59337,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.SPI1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>spi1,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -65808,18 +59361,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -65836,16 +59377,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -65859,10 +59392,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -65925,10 +59454,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioj0j3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_sgpm</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -65949,18 +59474,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -65977,16 +59490,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -66000,10 +59505,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -66024,10 +59525,6 @@
 	<child_id>chip-bmc-ast2500.GPIOJ1</child_id>
 	<child_id>chip-bmc-ast2500.GPIOJ2</child_id>
 	<child_id>chip-bmc-ast2500.GPIOJ3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -66053,18 +59550,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -66081,16 +59566,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -66104,10 +59581,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -66378,10 +59851,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.SGPM</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -66406,18 +59875,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -66434,16 +59891,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -66457,10 +59906,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -66477,10 +59922,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.SGPM</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -66502,18 +59943,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -66530,16 +59959,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -66553,10 +59974,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -66576,10 +59993,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioj4j7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_vga</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -66600,18 +60013,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -66628,16 +60029,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -66651,10 +60044,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -66676,10 +60065,6 @@
 	<child_id>chip-bmc-ast2500.GPIOJ6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOJ7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -66704,18 +60089,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -66732,16 +60105,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -66755,10 +60120,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -67029,10 +60390,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.VGA</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -67057,18 +60414,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -67085,16 +60430,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -67108,10 +60445,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -67128,10 +60461,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.VGA</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -67153,18 +60482,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -67181,16 +60498,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -67204,10 +60513,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -67227,10 +60532,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiok0k1</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -67251,18 +60552,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -67279,16 +60568,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -67302,10 +60583,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -67324,10 +60601,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOK0</child_id>
 	<child_id>chip-bmc-ast2500.GPIOK1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -67353,18 +60626,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -67381,16 +60642,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -67404,10 +60657,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -67552,10 +60801,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -67580,18 +60825,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -67608,16 +60841,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -67631,10 +60856,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -67705,10 +60926,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiok2k3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -67729,18 +60946,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -67757,16 +60962,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -67780,10 +60977,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -67802,10 +60995,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOK2</child_id>
 	<child_id>chip-bmc-ast2500.GPIOK3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -67831,18 +61020,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -67859,16 +61036,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -67882,10 +61051,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -68030,10 +61195,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -68058,18 +61219,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -68086,16 +61235,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -68109,10 +61250,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -68183,10 +61320,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiok4k5</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -68207,18 +61340,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -68235,16 +61356,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -68258,10 +61371,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -68280,10 +61389,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOK4</child_id>
 	<child_id>chip-bmc-ast2500.GPIOK5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -68309,18 +61414,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -68337,16 +61430,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -68360,10 +61445,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -68508,10 +61589,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -68536,18 +61613,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -68564,16 +61629,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -68587,10 +61644,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -68661,10 +61714,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiok6k7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c8</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -68685,18 +61734,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -68713,16 +61750,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -68736,10 +61765,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -68758,10 +61783,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOK6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOK7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -68787,18 +61808,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -68815,16 +61824,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -68838,10 +61839,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -68986,10 +61983,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C8</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -69014,18 +62007,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -69042,16 +62023,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -69065,10 +62038,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -69139,10 +62108,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiol0l7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_uart1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -69163,18 +62128,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -69191,16 +62144,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -69214,10 +62159,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -69243,10 +62184,6 @@
 	<child_id>chip-bmc-ast2500.GPIOL6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOL7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -69271,18 +62208,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -69299,16 +62224,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -69322,10 +62239,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -69848,10 +62761,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.UART1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>txd1,rxd1,nrts1,ndtr1,ndsr1,ncts1,ndcd1,nri1</default>
 	</attribute>
@@ -69876,18 +62785,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -69904,16 +62801,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -69927,10 +62816,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -69981,10 +62866,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiom0m7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_uart2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -70005,18 +62886,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -70033,16 +62902,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -70056,10 +62917,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -70085,10 +62942,6 @@
 	<child_id>chip-bmc-ast2500.GPIOM6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOM7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -70113,18 +62966,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -70141,16 +62982,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -70164,10 +62997,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -70690,10 +63519,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.UART2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>txd2,rxd2,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -70718,18 +63543,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -70746,16 +63559,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -70769,10 +63574,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -70823,10 +63624,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpion0</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_pwm0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -70847,18 +63644,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -70875,16 +63660,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -70898,10 +63675,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -70919,10 +63692,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpion0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPION0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -70948,18 +63717,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -70976,16 +63733,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -70999,10 +63748,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -71084,10 +63829,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.PWM0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -71112,18 +63853,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -71140,16 +63869,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -71163,10 +63884,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -71237,10 +63954,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpion1</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_pwm1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -71261,18 +63974,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -71289,16 +63990,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -71312,10 +64005,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -71333,10 +64022,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpion1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPION1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -71362,18 +64047,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -71390,16 +64063,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -71413,10 +64078,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -71498,10 +64159,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.PWM1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -71526,18 +64183,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -71554,16 +64199,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -71577,10 +64214,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -71651,10 +64284,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpion2</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_pwm2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -71675,18 +64304,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -71703,16 +64320,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -71726,10 +64335,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -71747,10 +64352,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpion2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPION2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -71776,18 +64377,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -71804,16 +64393,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -71827,10 +64408,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -71912,10 +64489,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.PWM2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -71940,18 +64513,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -71968,16 +64529,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -71991,10 +64544,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -72065,10 +64614,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpion3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_pwm3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -72089,18 +64634,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -72117,16 +64650,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -72140,10 +64665,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -72161,10 +64682,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpion3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPION3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -72190,18 +64707,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -72218,16 +64723,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -72241,10 +64738,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -72326,10 +64819,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.PWM3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -72354,18 +64843,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -72382,16 +64859,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -72405,10 +64874,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -72479,10 +64944,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpion4</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_pwm4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -72503,18 +64964,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -72531,16 +64980,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -72554,10 +64995,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -72575,10 +65012,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpion4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPION4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -72604,18 +65037,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -72632,16 +65053,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -72655,10 +65068,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -72740,10 +65149,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.PWM4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -72768,18 +65173,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -72796,16 +65189,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -72819,10 +65204,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -72893,10 +65274,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpion5</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_pwm5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -72917,18 +65294,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -72945,16 +65310,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -72968,10 +65325,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -72989,10 +65342,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpion5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPION5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -73018,18 +65367,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -73046,16 +65383,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -73069,10 +65398,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -73154,10 +65479,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.PWM5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -73182,18 +65503,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -73210,16 +65519,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -73233,10 +65534,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -73307,10 +65604,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpion6</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_pwm6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -73331,18 +65624,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -73359,16 +65640,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -73382,10 +65655,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -73403,10 +65672,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpion6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPION6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -73432,18 +65697,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -73460,16 +65713,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -73483,10 +65728,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -73568,10 +65809,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.PWM6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -73596,18 +65833,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -73624,16 +65849,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -73647,10 +65864,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -73721,10 +65934,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpion7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_pwm7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -73745,18 +65954,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -73773,16 +65970,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -73796,10 +65985,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -73817,10 +66002,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpion7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPION7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -73846,18 +66027,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -73874,16 +66043,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -73897,10 +66058,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -73982,10 +66139,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.PWM7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -74010,18 +66163,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -74038,16 +66179,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -74061,10 +66194,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -74135,10 +66264,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioo0</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -74159,18 +66284,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -74187,16 +66300,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -74210,10 +66315,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -74231,10 +66332,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioo0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOO0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -74260,18 +66357,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -74288,16 +66373,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -74311,10 +66388,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -74396,10 +66469,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -74424,18 +66493,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -74452,16 +66509,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -74475,10 +66524,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -74589,10 +66634,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioo1</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -74613,18 +66654,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -74641,16 +66670,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -74664,10 +66685,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -74685,10 +66702,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioo1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOO1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -74714,18 +66727,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -74742,16 +66743,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -74765,10 +66758,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -74850,10 +66839,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -74878,18 +66863,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -74906,16 +66879,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -74929,10 +66894,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -75043,10 +67004,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioo2</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -75067,18 +67024,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -75095,16 +67040,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -75118,10 +67055,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -75139,10 +67072,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioo2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOO2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -75168,18 +67097,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -75196,16 +67113,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -75219,10 +67128,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -75304,10 +67209,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -75332,18 +67233,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -75360,16 +67249,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -75383,10 +67264,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -75497,10 +67374,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioo3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -75521,18 +67394,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -75549,16 +67410,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -75572,10 +67425,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -75593,10 +67442,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioo3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOO3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -75622,18 +67467,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -75650,16 +67483,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -75673,10 +67498,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -75758,10 +67579,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -75786,18 +67603,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -75814,16 +67619,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -75837,10 +67634,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -75951,10 +67744,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioo4</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -75975,18 +67764,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -76003,16 +67780,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -76026,10 +67795,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -76047,10 +67812,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioo4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOO4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -76076,18 +67837,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -76104,16 +67853,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -76127,10 +67868,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -76212,10 +67949,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -76240,18 +67973,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -76268,16 +67989,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -76291,10 +68004,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -76405,10 +68114,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioo5</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -76429,18 +68134,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -76457,16 +68150,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -76480,10 +68165,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -76501,10 +68182,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioo5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOO5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -76530,18 +68207,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -76558,16 +68223,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -76581,10 +68238,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -76666,10 +68319,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -76694,18 +68343,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -76722,16 +68359,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -76745,10 +68374,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -76859,10 +68484,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioo6</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -76883,18 +68504,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -76911,16 +68520,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -76934,10 +68535,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -76955,10 +68552,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioo6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOO6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -76984,18 +68577,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -77012,16 +68593,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -77035,10 +68608,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -77120,10 +68689,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -77148,18 +68713,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -77176,16 +68729,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -77199,10 +68744,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -77313,10 +68854,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioo7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -77337,18 +68874,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -77365,16 +68890,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -77388,10 +68905,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -77409,10 +68922,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioo7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOO7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -77438,18 +68947,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -77466,16 +68963,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -77489,10 +68978,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -77574,10 +69059,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -77602,18 +69083,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -77630,16 +69099,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -77653,10 +69114,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -77767,10 +69224,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiop0</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach8</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -77791,18 +69244,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -77819,16 +69260,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -77842,10 +69275,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -77863,10 +69292,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiop0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOP0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -77892,18 +69317,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -77920,16 +69333,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -77943,10 +69348,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -78028,10 +69429,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH8</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -78056,18 +69453,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -78084,16 +69469,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -78107,10 +69484,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -78221,10 +69594,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiop1</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach9</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -78245,18 +69614,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -78273,16 +69630,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -78296,10 +69645,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -78317,10 +69662,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiop1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOP1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -78346,18 +69687,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -78374,16 +69703,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -78397,10 +69718,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -78482,10 +69799,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH9</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -78510,18 +69823,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -78538,16 +69839,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -78561,10 +69854,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -78675,10 +69964,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiop2</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach10</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -78699,18 +69984,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -78727,16 +70000,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -78750,10 +70015,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -78771,10 +70032,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiop2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOP2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -78800,18 +70057,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -78828,16 +70073,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -78851,10 +70088,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -78936,10 +70169,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH10</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -78964,18 +70193,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -78992,16 +70209,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -79015,10 +70224,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -79129,10 +70334,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiop3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach11</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -79153,18 +70354,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -79181,16 +70370,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -79204,10 +70385,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -79225,10 +70402,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiop3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOP3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -79254,18 +70427,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -79282,16 +70443,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -79305,10 +70458,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -79390,10 +70539,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH11</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -79418,18 +70563,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -79446,16 +70579,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -79469,10 +70594,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -79583,10 +70704,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiop4</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach12</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -79607,18 +70724,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -79635,16 +70740,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -79658,10 +70755,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -79679,10 +70772,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiop4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOP4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -79708,18 +70797,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -79736,16 +70813,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -79759,10 +70828,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -79844,10 +70909,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH12</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -79872,18 +70933,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -79900,16 +70949,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -79923,10 +70964,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -80037,10 +71074,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiop5</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach13</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -80061,18 +71094,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -80089,16 +71110,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -80112,10 +71125,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -80133,10 +71142,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiop5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOP5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -80162,18 +71167,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -80190,16 +71183,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -80213,10 +71198,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -80298,10 +71279,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH13</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -80326,18 +71303,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -80354,16 +71319,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -80377,10 +71334,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -80491,10 +71444,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiop6</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach14</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -80515,18 +71464,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -80543,16 +71480,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -80566,10 +71495,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -80587,10 +71512,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiop6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOP6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -80616,18 +71537,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -80644,16 +71553,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -80667,10 +71568,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -80752,10 +71649,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH14</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -80780,18 +71673,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -80808,16 +71689,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -80831,10 +71704,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -80945,10 +71814,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpiop7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_tach15</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -80969,18 +71834,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -80997,16 +71850,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -81020,10 +71865,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -81041,10 +71882,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpiop7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOP7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -81070,18 +71907,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -81098,16 +71923,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -81121,10 +71938,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -81206,10 +72019,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.TACH15</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -81234,18 +72043,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -81262,16 +72059,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -81285,10 +72074,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -81399,10 +72184,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioq0q1</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -81423,18 +72204,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -81451,16 +72220,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -81474,10 +72235,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -81496,10 +72253,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOQ0</child_id>
 	<child_id>chip-bmc-ast2500.GPIOQ1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -81525,18 +72278,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -81553,16 +72294,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -81576,10 +72309,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -81724,10 +72453,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -81752,18 +72477,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -81780,16 +72493,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -81803,10 +72508,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -81877,10 +72578,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioq2q3</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -81901,18 +72598,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -81929,16 +72614,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -81952,10 +72629,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -81974,10 +72647,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOQ2</child_id>
 	<child_id>chip-bmc-ast2500.GPIOQ3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -82003,18 +72672,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -82031,16 +72688,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -82054,10 +72703,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -82202,10 +72847,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -82230,18 +72871,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -82258,16 +72887,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -82281,10 +72902,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -82355,10 +72972,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioq4q5</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c14</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -82379,18 +72992,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -82407,16 +73008,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -82430,10 +73023,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -82452,10 +73041,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOQ4</child_id>
 	<child_id>chip-bmc-ast2500.GPIOQ5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -82481,18 +73066,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -82509,16 +73082,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -82532,10 +73097,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -82680,10 +73241,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C14</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -82708,18 +73265,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -82736,16 +73281,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -82759,10 +73296,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -82832,10 +73365,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioq6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -82856,18 +73385,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -82884,16 +73401,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -82907,10 +73416,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -82928,10 +73433,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioq6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOQ6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -82957,18 +73458,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -82985,16 +73474,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -83008,10 +73489,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -83093,10 +73570,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioq7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -83117,18 +73590,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -83145,16 +73606,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -83168,10 +73621,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -83189,10 +73638,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioq7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOQ7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -83218,18 +73663,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -83246,16 +73679,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -83269,10 +73694,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -83354,10 +73775,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpior0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -83378,18 +73795,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -83406,16 +73811,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -83429,10 +73826,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -83450,10 +73843,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpior0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOR0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -83479,18 +73868,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -83507,16 +73884,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -83530,10 +73899,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -83615,10 +73980,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpior1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -83639,18 +74000,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -83667,16 +74016,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -83690,10 +74031,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -83711,10 +74048,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpior1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOR1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -83740,18 +74073,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -83768,16 +74089,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -83791,10 +74104,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -83877,10 +74186,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpior2r5</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_spi2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -83901,18 +74206,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -83929,16 +74222,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -83952,10 +74237,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -83976,10 +74257,6 @@
 	<child_id>chip-bmc-ast2500.GPIOR3</child_id>
 	<child_id>chip-bmc-ast2500.GPIOR4</child_id>
 	<child_id>chip-bmc-ast2500.GPIOR5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -84005,18 +74282,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -84033,16 +74298,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -84056,10 +74313,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -84330,10 +74583,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.SPI2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>spi2ck,spi2cs0,spi2cs1,spi2miso,spi2mosi,NA,NA,NA</default>
 	</attribute>
@@ -84358,18 +74607,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -84386,16 +74623,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -84409,10 +74638,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -84474,10 +74699,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpior6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -84498,18 +74719,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -84526,16 +74735,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -84549,10 +74750,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -84570,10 +74767,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpior6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOR6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -84599,18 +74792,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -84627,16 +74808,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -84650,10 +74823,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -84735,10 +74904,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpior7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -84759,18 +74924,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -84787,16 +74940,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -84810,10 +74955,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -84831,10 +74972,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpior7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOR7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -84860,18 +74997,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -84888,16 +75013,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -84911,10 +75028,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -84996,10 +75109,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpios0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -85020,18 +75129,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -85048,16 +75145,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -85071,10 +75160,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -85092,10 +75177,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpios0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOS0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -85121,18 +75202,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -85149,16 +75218,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -85172,10 +75233,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -85257,10 +75314,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpios1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -85281,18 +75334,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -85309,16 +75350,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -85332,10 +75365,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -85353,10 +75382,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpios1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOS1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -85382,18 +75407,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -85410,16 +75423,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -85433,10 +75438,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -85518,10 +75519,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpios2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -85542,18 +75539,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -85570,16 +75555,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -85593,10 +75570,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -85614,10 +75587,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpios2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOS2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -85643,18 +75612,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -85671,16 +75628,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -85694,10 +75643,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -85779,10 +75724,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpios3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -85803,18 +75744,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -85831,16 +75760,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -85854,10 +75775,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -85875,10 +75792,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpios3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOS3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -85904,18 +75817,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -85932,16 +75833,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -85955,10 +75848,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -86040,10 +75929,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpios4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -86064,18 +75949,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -86092,16 +75965,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -86115,10 +75980,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -86136,10 +75997,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpios4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOS4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -86165,18 +76022,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -86193,16 +76038,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -86216,10 +76053,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -86301,10 +76134,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpios5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -86325,18 +76154,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -86353,16 +76170,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -86376,10 +76185,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -86397,10 +76202,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpios5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOS5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -86426,18 +76227,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -86454,16 +76243,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -86477,10 +76258,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -86562,10 +76339,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpios6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -86586,18 +76359,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -86614,16 +76375,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -86637,10 +76390,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -86658,10 +76407,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpios6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOS6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -86687,18 +76432,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -86715,16 +76448,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -86738,10 +76463,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -86823,10 +76544,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpios7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -86847,18 +76564,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -86875,16 +76580,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -86898,10 +76595,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -86919,10 +76612,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpios7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOS7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -86948,18 +76637,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -86976,16 +76653,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -86999,10 +76668,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -87084,10 +76749,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioy0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -87108,18 +76769,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -87136,16 +76785,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -87159,10 +76800,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -87180,10 +76817,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioy0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOY0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -87209,18 +76842,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -87237,16 +76858,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -87260,10 +76873,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -87345,10 +76954,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioy1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -87369,18 +76974,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -87397,16 +76990,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -87420,10 +77005,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -87441,10 +77022,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioy1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOY1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -87470,18 +77047,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -87498,16 +77063,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -87521,10 +77078,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -87606,10 +77159,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioy2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -87630,18 +77179,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -87658,16 +77195,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -87681,10 +77210,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -87702,10 +77227,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioy2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOY2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -87731,18 +77252,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -87759,16 +77268,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -87782,10 +77283,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -87867,10 +77364,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioy3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -87891,18 +77384,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -87919,16 +77400,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -87942,10 +77415,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -87963,10 +77432,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioy3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOY3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -87992,18 +77457,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -88020,16 +77473,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -88043,10 +77488,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -88129,10 +77570,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioy4y5</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -88153,18 +77590,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -88181,16 +77606,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -88204,10 +77621,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -88226,10 +77639,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOY4</child_id>
 	<child_id>chip-bmc-ast2500.GPIOY5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -88255,18 +77664,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -88283,16 +77680,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -88306,10 +77695,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -88454,10 +77839,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -88482,18 +77863,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -88510,16 +77879,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -88533,10 +77894,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -88607,10 +77964,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_gpioy6y7</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_i2c2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -88631,18 +77984,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -88659,16 +78000,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -88682,10 +78015,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -88704,10 +78033,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOY6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOY7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -88733,18 +78058,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -88761,16 +78074,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -88784,10 +78089,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -88932,10 +78233,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.I2C2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -88960,18 +78257,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -88988,16 +78273,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -89011,10 +78288,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -89084,10 +78357,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioz0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -89108,18 +78377,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -89136,16 +78393,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -89159,10 +78408,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -89180,10 +78425,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioz0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOZ0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -89209,18 +78450,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -89237,16 +78466,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -89260,10 +78481,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -89345,10 +78562,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioz1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -89369,18 +78582,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -89397,16 +78598,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -89420,10 +78613,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -89441,10 +78630,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioz1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOZ1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -89470,18 +78655,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -89498,16 +78671,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -89521,10 +78686,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -89606,10 +78767,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioz2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -89630,18 +78787,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -89658,16 +78803,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -89681,10 +78818,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -89702,10 +78835,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioz2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOZ2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -89731,18 +78860,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -89759,16 +78876,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -89782,10 +78891,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -89867,10 +78972,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioz3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -89891,18 +78992,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -89919,16 +79008,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -89942,10 +79023,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -89963,10 +79040,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioz3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOZ3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -89992,18 +79065,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -90020,16 +79081,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -90043,10 +79096,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -90128,10 +79177,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioz4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -90152,18 +79197,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -90180,16 +79213,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -90203,10 +79228,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -90224,10 +79245,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioz4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOZ4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -90253,18 +79270,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -90281,16 +79286,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -90304,10 +79301,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -90389,10 +79382,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioz5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -90413,18 +79402,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -90441,16 +79418,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -90464,10 +79433,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -90485,10 +79450,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioz5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOZ5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -90514,18 +79475,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -90542,16 +79491,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -90565,10 +79506,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -90650,10 +79587,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioz6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -90674,18 +79607,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -90702,16 +79623,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -90725,10 +79638,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -90746,10 +79655,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioz6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOZ6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -90775,18 +79680,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -90803,16 +79696,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -90826,10 +79711,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -90911,10 +79792,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioz7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -90935,18 +79812,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -90963,16 +79828,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -90986,10 +79843,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -91007,10 +79860,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioz7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOZ7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -91036,18 +79885,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -91064,16 +79901,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -91087,10 +79916,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -91172,10 +79997,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioaa0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -91196,18 +80017,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -91224,16 +80033,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -91247,10 +80048,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -91268,10 +80065,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioaa0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAA0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -91297,18 +80090,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -91325,16 +80106,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -91348,10 +80121,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -91433,10 +80202,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioaa1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -91457,18 +80222,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -91485,16 +80238,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -91508,10 +80253,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -91529,10 +80270,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioaa1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAA1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -91558,18 +80295,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -91586,16 +80311,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -91609,10 +80326,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -91694,10 +80407,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioaa2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -91718,18 +80427,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -91746,16 +80443,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -91769,10 +80458,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -91790,10 +80475,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioaa2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAA2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -91819,18 +80500,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -91847,16 +80516,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -91870,10 +80531,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -91955,10 +80612,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioaa3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -91979,18 +80632,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -92007,16 +80648,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -92030,10 +80663,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -92051,10 +80680,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioaa3</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAB3</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -92080,18 +80705,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -92108,16 +80721,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -92131,10 +80736,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -92216,10 +80817,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioaa4</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -92240,18 +80837,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -92268,16 +80853,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -92291,10 +80868,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -92312,10 +80885,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioaa4</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAA4</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -92341,18 +80910,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -92369,16 +80926,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -92392,10 +80941,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -92477,10 +81022,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioaa5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -92501,18 +81042,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -92529,16 +81058,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -92552,10 +81073,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -92573,10 +81090,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioaa5</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAA5</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -92602,18 +81115,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -92630,16 +81131,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -92653,10 +81146,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -92738,10 +81227,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioaa6</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -92762,18 +81247,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -92790,16 +81263,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -92813,10 +81278,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -92834,10 +81295,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioaa6</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAA6</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -92863,18 +81320,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -92891,16 +81336,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -92914,10 +81351,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -92999,10 +81432,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioaa7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -93023,18 +81452,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -93051,16 +81468,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -93074,10 +81483,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -93095,10 +81500,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioaa7</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAA7</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -93124,18 +81525,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -93152,16 +81541,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -93175,10 +81556,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -93260,10 +81637,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioab0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -93284,18 +81657,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -93312,16 +81673,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -93335,10 +81688,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -93356,10 +81705,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioab0</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAB0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -93385,18 +81730,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -93413,16 +81746,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -93436,10 +81761,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -93521,10 +81842,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioab1</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -93545,18 +81862,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -93573,16 +81878,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -93596,10 +81893,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -93617,10 +81910,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioab1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAB1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -93646,18 +81935,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -93674,16 +81951,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -93697,10 +81966,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -93782,10 +82047,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioab2</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -93806,18 +82067,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -93834,16 +82083,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -93857,10 +82098,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -93878,10 +82115,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_gpioab2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.GPIOAB2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -93907,18 +82140,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -93935,16 +82156,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -93958,10 +82171,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -94043,10 +82252,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.pingroup_gpioaa3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -94067,18 +82272,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -94095,16 +82288,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -94118,10 +82303,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -94142,10 +82323,6 @@
 	<child_id>chip-bmc-ast2500.pingroup_lpc</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpioac0ac7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -94164,18 +82341,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -94194,16 +82359,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -94217,10 +82374,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -94239,10 +82392,6 @@
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.ESPI</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -94265,18 +82414,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -94295,16 +82432,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -94318,10 +82447,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -94338,10 +82463,6 @@
 	<is_root>false</is_root>
 	<instance_name>chip-bmc-ast2500.ESPI</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -94363,18 +82484,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -94391,16 +82500,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -94414,10 +82515,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -94435,10 +82532,6 @@
 	<instance_name>chip-bmc-ast2500.pingroup_lpc</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.LPC</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
@@ -94464,18 +82557,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -94492,16 +82573,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -94515,10 +82588,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -94575,10 +82644,6 @@
 	<child_id>chip-bmc-ast2500.GPIOAC6</child_id>
 	<child_id>chip-bmc-ast2500.GPIOAC7</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -94603,18 +82668,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -94631,16 +82684,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -94654,10 +82699,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -95182,10 +83223,6 @@
 	<child_id>chip-bmc-ast2500.rmii1</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiou4t5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -95206,18 +83243,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -95234,16 +83259,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -95257,10 +83274,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -95278,10 +83291,6 @@
 	<instance_name>chip-bmc-ast2500.rgmii1</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.RGMII1</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>rgmii1,mdio1,NA,NA,NA,NA,NA,NA</default>
@@ -95307,18 +83316,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -95335,16 +83332,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -95358,10 +83347,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -95428,10 +83413,6 @@
 	<child_id>chip-bmc-ast2500.GPIOT4</child_id>
 	<child_id>chip-bmc-ast2500.GPIOT5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>rmii1,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -95456,18 +83437,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -95484,16 +83453,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -95507,10 +83468,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -95774,10 +83731,6 @@
 	<child_id>chip-bmc-ast2500.GPIOT4</child_id>
 	<child_id>chip-bmc-ast2500.GPIOT5</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -95802,18 +83755,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -95830,16 +83771,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -95853,10 +83786,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -96444,10 +84373,6 @@
 	<child_id>chip-bmc-ast2500.rmii2</child_id>
 	<child_id>chip-bmc-ast2500.pingroup_gpiov2u3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -96468,18 +84393,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -96496,16 +84409,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -96519,10 +84424,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -96540,10 +84441,6 @@
 	<instance_name>chip-bmc-ast2500.rgmii2</instance_name>
 	<position>-1</position>
 	<child_id>chip-bmc-ast2500.RGMII2</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>rgmii2,mdio2,NA,NA,NA,NA,NA,NA</default>
@@ -96569,18 +84466,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -96597,16 +84482,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -96620,10 +84497,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -96690,10 +84563,6 @@
 	<child_id>chip-bmc-ast2500.GPIOU2</child_id>
 	<child_id>chip-bmc-ast2500.GPIOU3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>rmii2,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -96718,18 +84587,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -96746,16 +84603,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -96769,10 +84618,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -97036,10 +84881,6 @@
 	<child_id>chip-bmc-ast2500.GPIOU2</child_id>
 	<child_id>chip-bmc-ast2500.GPIOU3</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_PINCTRL_FUNCS</id>
 		<default>NA,NA,NA,NA,NA,NA,NA,NA</default>
 	</attribute>
@@ -97064,18 +84905,6 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -97092,16 +84921,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IOMUX_GROUP</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -97115,10 +84936,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -97768,18 +85585,6 @@
 	<child_id>BMC_FLASH.spi-slave-0</child_id>
 	<child_id>BMC_FLASH.gpio-slave-0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>CCIN</id>
 		<default></default>
 	</attribute>
@@ -97792,28 +85597,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
 	</attribute>
 	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
@@ -97821,14 +85606,6 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -97851,16 +85628,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -97899,10 +85668,6 @@
 	<instance_name>BMC_FLASH.spi-slave</instance_name>
 	<position>0</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>SPI</default>
 	</attribute>
@@ -97927,18 +85692,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -97951,16 +85704,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -97974,10 +85719,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -98060,18 +85801,6 @@
 	<child_id>BMC_FLASH.spi-slave-0</child_id>
 	<child_id>BMC_FLASH.gpio-slave-0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>CCIN</id>
 		<default></default>
 	</attribute>
@@ -98084,28 +85813,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
 	</attribute>
 	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
@@ -98113,14 +85822,6 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -98143,16 +85844,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -98213,10 +85906,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -98244,10 +85933,6 @@
 	<instance_name>PNOR_FLASH.spi-slave</instance_name>
 	<position>0</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>SPI</default>
 	</attribute>
@@ -98272,18 +85957,6 @@
 		<default>IN</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -98296,16 +85969,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -98319,10 +85984,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -98416,10 +86077,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -98507,10 +86164,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>VPD</default>
 	</attribute>
@@ -98587,18 +86240,6 @@
 	<child_id>pciep</child_id>
 	<child_id>perst</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>CLASS</id>
 		<default>CHIP</default>
 	</attribute>
@@ -98607,28 +86248,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
 	</attribute>
 	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
@@ -98636,14 +86257,6 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -98658,16 +86271,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -98863,10 +86468,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -98934,10 +86535,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -98971,18 +86568,6 @@
 	<child_id>fsi_bit_bang.fsi_enable</child_id>
 	<child_id>fsi_bit_bang.fsi_trans</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>CLASS</id>
 		<default>CHIP</default>
 	</attribute>
@@ -98991,28 +86576,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
 	</attribute>
 	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
@@ -99020,14 +86585,6 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -99046,16 +86603,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -99220,10 +86769,6 @@
 	<instance_name>fsi_bit_bang.fsi_master</instance_name>
 	<position>0</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>FSIM</default>
 	</attribute>
@@ -99252,14 +86797,6 @@
 		<default>OUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FSI_ENGINE</id>
 		<default>0x00</default>
 	</attribute>
@@ -99270,10 +86807,6 @@
 	<attribute>
 		<id>FSI_PORT</id>
 		<default>0x00</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -99288,16 +86821,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSIM</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -99311,10 +86836,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -99544,18 +87065,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>CLASS</id>
 		<default>CHIP</default>
 	</attribute>
@@ -99568,28 +87077,8 @@
 		<default>0x8241</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
 	</attribute>
 	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
@@ -99597,14 +87086,6 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -99623,20 +87104,12 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
 	<attribute>
 		<id>MSI</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -100315,10 +87788,6 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
-		<bus_attribute>
-			<id>ISDIMM_MBVPD_INDEX</id>
-		<default>0</default>
-		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>fanconn-11/fan-6/fan-fault-led-7/generic-logic-assoc => fanconn-11/fan-6/led_assoc_child</bus_id>
@@ -100331,10 +87800,6 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>ISDIMM_MBVPD_INDEX</id>
-		<default>0</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -100349,10 +87814,6 @@
 			<id>CLASS</id>
 		<default>BUS</default>
 		</bus_attribute>
-		<bus_attribute>
-			<id>ISDIMM_MBVPD_INDEX</id>
-		<default>0</default>
-		</bus_attribute>
 	</bus>
 	<bus>
 		<bus_id>fanconn-13/fan-8/fan-fault-led-9/generic-logic-assoc => fanconn-13/fan-8/led_assoc_child</bus_id>
@@ -100365,10 +87826,6 @@
 		<bus_attribute>
 			<id>CLASS</id>
 		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>ISDIMM_MBVPD_INDEX</id>
-		<default>0</default>
 		</bus_attribute>
 	</bus>
 	<bus>
@@ -100506,10 +87963,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -100976,10 +88429,6 @@
 	<instance_name>MAX31785.hwmon0</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -100998,18 +88447,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -101035,16 +88472,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -101058,10 +88487,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -101171,10 +88596,6 @@
 	<instance_name>MAX31785.hwmon1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -101193,18 +88614,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -101230,16 +88639,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -101253,10 +88654,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -101366,10 +88763,6 @@
 	<instance_name>MAX31785.hwmon2</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -101388,18 +88781,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -101425,16 +88806,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -101448,10 +88821,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -101561,10 +88930,6 @@
 	<instance_name>MAX31785.hwmon3</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -101583,18 +88948,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -101620,16 +88973,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -101643,10 +88988,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -101756,10 +89097,6 @@
 	<instance_name>MAX31785.hwmon4</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -101778,18 +89115,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -101815,16 +89140,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -101838,10 +89155,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -101951,10 +89264,6 @@
 	<instance_name>MAX31785.hwmon5</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -101973,18 +89282,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -102010,16 +89307,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -102033,10 +89322,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -102077,10 +89362,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -102188,10 +89469,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -103889,10 +91166,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -104375,10 +91648,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -104628,10 +91897,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -104879,10 +92144,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -105167,18 +92428,6 @@
 	<child_id>UCD90160.in15</child_id>
 	<child_id>UCD90160.in16</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>BMC_DT_COMPATIBLE</id>
 		<default>ti,ucd90160</default>
 	</attribute>
@@ -105191,28 +92440,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
 	</attribute>
 	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
@@ -105220,14 +92449,6 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -105242,16 +92463,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -105329,10 +92542,6 @@
 	<instance_name>UCD90160.in1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -105351,18 +92560,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -105388,16 +92585,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -105411,10 +92600,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -105431,10 +92616,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in2</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -105454,18 +92635,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -105491,16 +92660,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -105514,10 +92675,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -105534,10 +92691,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in3</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -105557,18 +92710,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -105594,16 +92735,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -105617,10 +92750,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -105637,10 +92766,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in4</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -105660,18 +92785,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -105697,16 +92810,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -105720,10 +92825,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -105740,10 +92841,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in5</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -105763,18 +92860,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -105800,16 +92885,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -105823,10 +92900,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -105843,10 +92916,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in6</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -105866,18 +92935,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -105903,16 +92960,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -105926,10 +92975,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -105946,10 +92991,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in7</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -105969,18 +93010,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106006,16 +93035,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106029,10 +93050,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -106049,10 +93066,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in8</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -106072,18 +93085,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106109,16 +93110,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106132,10 +93125,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -106152,10 +93141,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in9</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -106175,18 +93160,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106212,16 +93185,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106235,10 +93200,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -106255,10 +93216,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in10</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -106278,18 +93235,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106315,16 +93260,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106338,10 +93275,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -106358,10 +93291,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in11</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -106381,18 +93310,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106418,16 +93335,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106441,10 +93350,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -106461,10 +93366,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in12</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -106484,18 +93385,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106521,16 +93410,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106544,10 +93425,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -106564,10 +93441,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in13</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -106587,18 +93460,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106624,16 +93485,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106647,10 +93500,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -106667,10 +93516,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in14</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -106690,18 +93535,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106727,16 +93560,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106750,10 +93575,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -106770,10 +93591,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in15</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -106793,18 +93610,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106830,16 +93635,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106853,10 +93650,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -106873,10 +93666,6 @@
 	<is_root>false</is_root>
 	<instance_name>UCD90160.in16</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -106896,18 +93685,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -106933,16 +93710,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -106956,10 +93725,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -107018,10 +93783,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -107064,10 +93825,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default>TMP423A</default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -107136,10 +93893,6 @@
 	<instance_name>TMP423A.temp1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -107158,18 +93911,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -107195,16 +93936,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -107218,10 +93951,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -107238,10 +93967,6 @@
 	<is_root>false</is_root>
 	<instance_name>TMP423A.temp2</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -107261,18 +93986,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -107298,16 +94011,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -107321,10 +94026,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -107341,10 +94042,6 @@
 	<is_root>false</is_root>
 	<instance_name>TMP423A.temp3</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -107364,18 +94061,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -107401,16 +94086,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -107424,10 +94101,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -107444,10 +94117,6 @@
 	<is_root>false</is_root>
 	<instance_name>TMP423A.temp4</instance_name>
 	<position>-1</position>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
 	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
@@ -107467,18 +94136,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -107504,16 +94161,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -107527,10 +94176,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -107563,10 +94208,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default>TMP423A</default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -107608,10 +94249,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default>TMP275</default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -107680,10 +94317,6 @@
 	<instance_name>TMP275.temp1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -107702,18 +94335,6 @@
 	<attribute>
 		<id>DECONFIG_GARDABLE</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -107739,16 +94360,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -107762,10 +94375,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -107897,10 +94506,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -108683,10 +95288,6 @@
 	<hidden_child_id>gpu_func_sensor</hidden_child_id>
 	<hidden_child_id>memory_temp_sensor</hidden_child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>CLASS</id>
 		<default>CARD</default>
 	</attribute>
@@ -108697,18 +95298,6 @@
 	<attribute>
 		<id>DEVICE_ID</id>
 		<default>0x1DB1</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -108725,10 +95314,6 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -108775,10 +95360,6 @@
 	<instance_name>brick-0</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
 	</attribute>
@@ -108803,18 +95384,6 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -108827,16 +95396,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -108850,10 +95411,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -108871,10 +95428,6 @@
 	<instance_name>brick-1</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
 	</attribute>
@@ -108899,18 +95452,6 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -108923,16 +95464,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -108946,10 +95479,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -108967,10 +95496,6 @@
 	<instance_name>brick-2</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
 	</attribute>
@@ -108995,18 +95520,6 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -109019,16 +95532,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -109042,10 +95547,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -109063,10 +95564,6 @@
 	<instance_name>brick-3</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
 	</attribute>
@@ -109091,18 +95588,6 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -109115,16 +95600,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -109138,10 +95615,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -109159,10 +95632,6 @@
 	<instance_name>brick-4</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
 	</attribute>
@@ -109187,18 +95656,6 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -109211,16 +95668,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -109234,10 +95683,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -109255,10 +95700,6 @@
 	<instance_name>brick-5</instance_name>
 	<position>-1</position>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>BUS_TYPE</id>
 		<default>OBUS</default>
 	</attribute>
@@ -109283,18 +95724,6 @@
 		<default>INOUT</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
 		<default></default>
 	</attribute>
@@ -109307,16 +95736,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0x00</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -109330,10 +95751,6 @@
 				<field><id>supportsInbandScom</id><value>0</value></field>
 				<field><id>reserved</id><value>0</value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>REL_POS</id>
-		<default>0xFF</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -109811,10 +96228,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -112281,10 +98694,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -112948,10 +99357,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -113095,10 +99500,6 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -113127,18 +99528,6 @@
 	<position>0</position>
 	<child_id>tpm.i2c-0</child_id>
 	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>ALTFSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
 		<id>CCIN</id>
 		<default></default>
 	</attribute>
@@ -113151,28 +99540,8 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
 		<id>FRU_ID</id>
 		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_CHIP</id>
-		<default>physical:sys-0</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_PORT</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>FSI_MASTER_TYPE</id>
-		<default>NO_MASTER</default>
 	</attribute>
 	<attribute>
 		<id>FSI_OPTION_FLAGS</id>
@@ -113180,14 +99549,6 @@
 				<field><id>flipPort</id><value></value></field>
 				<field><id>reserved</id><value></value></field>
 		</default>
-	</attribute>
-	<attribute>
-		<id>FSI_SLAVE_CASCADE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
 	</attribute>
 	<attribute>
 		<id>HWAS_STATE_CHANGED_FLAG</id>
@@ -113210,16 +99571,8 @@
 		<default></default>
 	</attribute>
 	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
 	</attribute>
 	<attribute>
 		<id>PHYS_PATH</id>
@@ -113340,10 +99693,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>
@@ -118346,10 +104695,6 @@
 	<attribute>
 		<id>MODEL</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>MRU_ID</id>
-		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>MRW_TYPE</id>


### PR DESCRIPTION
Hostboot now has an automatic way of generating attributes and
exporting them to common_mrw_xml. This update is picking up those
changes. We should really be just dropping all the unnecesary
attributes and the ones that manually set in processMrw.