### PR TITLE
Default Spectre/Meltdown HW Inits to Kernel mode

### DIFF
--- a/witherspoon.xml
+++ b/witherspoon.xml
@@ -17154,6 +17154,10 @@
 		<default>0xEC000000</default>
 	</attribute>
 	<attribute>
+		<id>MRW_DEFAULT_RISK_LEVEL</id>
+		<default>1</default>
+	</attribute>
+	<attribute>
 		<id>SUPPORTS_DYNAMIC_MEM_VOLT</id>
 		<default>0</default>
 	</attribute>


### PR DESCRIPTION
  Default Spectre/Meltdown HW Inits used to be "0" Kernel+User
  mitigations.  This commit changes the default to "1" for only
  Kernel mitigations.