### PR TITLE
Set IS_MPIPL_SUPPORTED to TRUE by default

### DIFF
--- a/witherspoon.xml
+++ b/witherspoon.xml
@@ -16152,7 +16152,7 @@
 	</attribute>
 	<attribute>
 		<id>IS_MPIPL_SUPPORTED</id>
-		<default>0</default>
+		<default>1</default>
 	</attribute>
 	<attribute>
 		<id>IS_SIMULATION</id>


### PR DESCRIPTION
Enabling MPIPL on Witherspoon system by default.